### PR TITLE
Interface definition for a simplified join/exit interface

### DIFF
--- a/balancer-js/src/pool-weighted/interface.ts
+++ b/balancer-js/src/pool-weighted/interface.ts
@@ -1,0 +1,66 @@
+import { BigNumberish } from '@ethersproject/bignumber';
+
+export interface PoolService {
+    /**
+     * Allow the input of any number of pool tokens, return the expected
+     * bptAmount and priceImpactPercent of the join.
+     *
+     * Internally do sanity checks to ensure that all input tokens are actually part of the pool.
+     */
+    queryJoin(poolId: string, tokens: SimpleToken[]): Promise<QueryJoinOutput>;
+    /**
+     * Given a single token as input, determine what a zero impact join looks like.
+     * Also return the expected bptAmount for a zero impact join.
+     */
+    queryBalancedJoin(poolId: string, token: SimpleToken): Promise<QueryBalancedJoinOutput>;
+    /**
+     * Given the input tokens, bptAmount, and maxSlippagePercent, encode the join operation.
+     */
+    encodeJoin(input: EncodeJoinInput): Promise<void>;
+
+    //TODO: having the queries resolve to a promise may not be performant enough (ie: the frontend percentage slider)
+    //TODO: Alternatively, we could pass the Pool in already resolved, or somehow cache the Pool in the SDK for some period of time.
+    queryBalancedExit(poolId: string, bptAmount: BigNumberish): Promise<QueryBalancedExitOutput>;
+    querySingleTokenExit(
+        poolId: string,
+        bptAmount: BigNumberish,
+        tokenAddress: string,
+    ): Promise<QuerySingleTokenExitOutput>;
+
+    encodeBalancedExit(poolId: string, bptAmount: BigNumberish, maxSlippagePercent: number): Promise<void>;
+    encodeSingleTokenExit(
+        poolId: string,
+        bptAmount: BigNumberish,
+        tokenAddress: string,
+        maxSlippagePercent: number,
+    ): Promise<void>;
+}
+
+interface QueryJoinOutput {
+    bptAmount: BigNumberish;
+    priceImpactPercent: number;
+}
+
+interface QueryBalancedJoinOutput {
+    tokens: SimpleToken[];
+    bptAmount: BigNumberish;
+}
+
+interface SimpleToken {
+    address: string;
+    amount: BigNumberish;
+}
+
+interface EncodeJoinInput {
+    tokens: SimpleToken[];
+    bptAmount: BigNumberish;
+    maxSlippagePercent: number;
+}
+
+interface QueryBalancedExitOutput {
+    tokens: SimpleToken[];
+}
+
+interface QuerySingleTokenExitOutput {
+    token: SimpleToken;
+}

--- a/balancer-js/src/pool-weighted/interface.ts
+++ b/balancer-js/src/pool-weighted/interface.ts
@@ -20,7 +20,13 @@ export interface PoolService {
 
     //TODO: having the queries resolve to a promise may not be performant enough (ie: the frontend percentage slider)
     //TODO: Alternatively, we could pass the Pool in already resolved, or somehow cache the Pool in the SDK for some period of time.
+    /**
+     * Return the balanced token amounts received for bptAmount in
+     */
     queryBalancedExit(poolId: string, bptAmount: BigNumberish): Promise<QueryBalancedExitOutput>;
+    /**
+     * Return the single token amount received for bptAmount in
+     */
     querySingleTokenExit(
         poolId: string,
         bptAmount: BigNumberish,

--- a/balancer-js/src/pool-weighted/interface.ts
+++ b/balancer-js/src/pool-weighted/interface.ts
@@ -1,5 +1,7 @@
 import { BigNumberish } from '@ethersproject/bignumber';
 
+//TODO: having the queries resolve to a promise may not be performant enough (ie: the frontend percentage slider)
+//TODO: Alternatively, we could have some sort of `init` factory function that handles all of the async loading for the session.
 export interface PoolService {
     /**
      * Allow the input of any number of pool tokens, return the expected
@@ -18,8 +20,6 @@ export interface PoolService {
      */
     encodeJoin(input: EncodeJoinInput): Promise<void>;
 
-    //TODO: having the queries resolve to a promise may not be performant enough (ie: the frontend percentage slider)
-    //TODO: Alternatively, we could pass the Pool in already resolved, or somehow cache the Pool in the SDK for some period of time.
     /**
      * Return the balanced token amounts received for bptAmount in
      */


### PR DESCRIPTION
This is meant to be an extension on the `encoder.ts` interfaces. The overarching goal here is to collapse the operations down to represent the simpler tasks the dev is trying to achieve. Rather than exposing all possibilities, we provide a limited interface and allow the SDK to figure out the best path given the inputs. Additionally, we can abstract away the distinction between Weighted and Stable pool join/exits and allow the SDK to figure it out based on the pool type.