### PR TITLE
Add functions to calculate stable and weighted pool liquidity

### DIFF
--- a/balancer-js/src/pool-stable/index.ts
+++ b/balancer-js/src/pool-stable/index.ts
@@ -1,1 +1,2 @@
 export * from './encoder';
+export * from './liquidity';

--- a/balancer-js/src/pool-stable/liquidity.spec.ts
+++ b/balancer-js/src/pool-stable/liquidity.spec.ts
@@ -1,0 +1,31 @@
+import { parseFixed } from '@ethersproject/bignumber';
+import { expect } from 'chai';
+import { calcStablePoolValue } from './liquidity';
+
+describe('calcStablePoolValue', () => {
+    context('when all token prices are known', () => {
+        it('correctly calculate the value in the pool', () => {
+            const balances = [parseFixed('100', 6), parseFixed('100', 18)];
+            const decimals = [6, 18];
+            const prices = [1, 1];
+
+            const expectedPoolValue = '200.0';
+            expect(calcStablePoolValue(balances, decimals, prices)).to.be.eq(
+                expectedPoolValue
+            );
+        });
+    });
+
+    context('when some token prices are unknown', () => {
+        it('correctly the value of the pool based on the remaining prices', () => {
+            const balances = [parseFixed('100', 6), parseFixed('100', 18)];
+            const decimals = [6, 18];
+            const prices = [null, 1];
+
+            const expectedPoolValue = '200.0';
+            expect(calcStablePoolValue(balances, decimals, prices)).to.be.eq(
+                expectedPoolValue
+            );
+        });
+    });
+});

--- a/balancer-js/src/pool-stable/liquidity.ts
+++ b/balancer-js/src/pool-stable/liquidity.ts
@@ -1,0 +1,91 @@
+import {
+    BigNumberish,
+    formatFixed,
+    parseFixed,
+} from '@ethersproject/bignumber';
+import { WeiPerEther as ONE, Zero } from '@ethersproject/constants';
+import invariant from 'tiny-invariant';
+
+export const calcStablePoolValue = (
+    tokenBalances: BigNumberish[],
+    tokenDecimals: number[],
+    tokenPrices: (number | null)[]
+): string =>
+    // Stable pools are a special case of MetaStable pools where all tokens have pricerate of 1.
+    calcMetaStablePoolValue(
+        tokenBalances,
+        tokenDecimals,
+        tokenBalances.map(() => ONE),
+        tokenPrices
+    );
+
+export const calcMetaStablePoolValue = (
+    tokenBalances: BigNumberish[],
+    tokenDecimals: number[],
+    tokenPriceRates: BigNumberish[],
+    tokenPrices: (number | null)[]
+): string => {
+    invariant(
+        tokenBalances.length === tokenDecimals.length,
+        'Input lengths mismatch'
+    );
+    invariant(
+        tokenBalances.length === tokenPriceRates.length,
+        'Input lengths mismatch'
+    );
+    invariant(
+        tokenBalances.length === tokenPrices.length,
+        'Input lengths mismatch'
+    );
+
+    // All token balances are scaled to 18 decimals
+    const scaledBalances = tokenBalances.map((balance, i) =>
+        parseFixed(balance.toString(), 18 - tokenDecimals[i])
+    );
+
+    let sumValue = Zero;
+    let sumBalance = Zero;
+
+    for (let i = 0; i < tokenBalances.length; i++) {
+        const scaledBalance = scaledBalances[i];
+        const priceRate = tokenPriceRates[i];
+        const price = tokenPrices[i];
+
+        // If a token's price is unknown, ignore it, it will be computed at the next step
+        if (price === null) {
+            continue;
+        }
+
+        // Apply the pricerate to convert the balance into the correct units
+        sumBalance = sumBalance.add(scaledBalance.mul(priceRate).div(ONE));
+
+        // Pricerate does not need to be applied here as it is already included in price
+        const value = scaledBalance
+            .mul(parseFixed(price.toFixed(18), 18))
+            .div(ONE);
+        sumValue = sumValue.add(value);
+    }
+
+    // If at least the partial value of the pool is known, then compute the rest of the value
+    if (sumBalance.gt(0)) {
+        // assume relative spot price = 1
+        const avgPrice = sumValue.mul(ONE).div(sumBalance);
+
+        for (let i = 0; i < tokenBalances.length; i++) {
+            const scaledBalance = scaledBalances[i];
+            const price = tokenPrices[i];
+
+            // If a token's price is known, skip it. It has been taken into account in the prev step
+            if (price !== null) {
+                continue;
+            }
+
+            const value = scaledBalance.mul(avgPrice).div(ONE);
+            sumValue = sumValue.add(value);
+        }
+
+        return formatFixed(sumValue, 18);
+    }
+
+    return '0';
+};

--- a/balancer-js/src/pool-weighted/index.ts
+++ b/balancer-js/src/pool-weighted/index.ts
@@ -1,2 +1,3 @@
 export * from './encoder';
+export * from './liquidity';
 export * from './normalizedWeights';

--- a/balancer-js/src/pool-weighted/liquidity.spec.ts
+++ b/balancer-js/src/pool-weighted/liquidity.spec.ts
@@ -1,0 +1,34 @@
+import { toNormalizedWeights } from './normalizedWeights';
+import { calcWeightedPoolValue } from './liquidity';
+import { parseFixed } from '@ethersproject/bignumber';
+import { expect } from 'chai';
+
+describe('calcWeightedPoolValue', () => {
+    context('when all token prices are known', () => {
+        it('correctly calculate the value in the pool', () => {
+            const balances = [parseFixed('100', 18), parseFixed('100', 18)];
+            const decimals = [18, 18];
+            const weights = toNormalizedWeights([50, 50]);
+            const prices = [0.5, 1];
+
+            const expectedPoolValue = '150.0';
+            expect(
+                calcWeightedPoolValue(balances, decimals, weights, prices)
+            ).to.be.eq(expectedPoolValue);
+        });
+    });
+
+    context('when some token prices are unknown', () => {
+        it('correctly the value of the pool based on the remaining prices', () => {
+            const balances = [parseFixed('100', 6), parseFixed('100', 18)];
+            const decimals = [6, 18];
+            const weights = toNormalizedWeights([80, 20]);
+            const prices = [0.5, null];
+
+            const expectedPoolValue = '62.5';
+            expect(
+                calcWeightedPoolValue(balances, decimals, weights, prices)
+            ).to.be.eq(expectedPoolValue);
+        });
+    });
+});

--- a/balancer-js/src/pool-weighted/liquidity.ts
+++ b/balancer-js/src/pool-weighted/liquidity.ts
@@ -1,0 +1,65 @@
+import {
+    BigNumber,
+    BigNumberish,
+    formatFixed,
+    parseFixed,
+} from '@ethersproject/bignumber';
+import { WeiPerEther as ONE, Zero } from '@ethersproject/constants';
+import invariant from 'tiny-invariant';
+
+export const calcWeightedPoolValue = (
+    tokenBalances: BigNumberish[],
+    tokenDecimals: number[],
+    tokenWeights: BigNumberish[],
+    tokenPrices: (number | null)[]
+): string => {
+    invariant(
+        tokenBalances.length === tokenWeights.length,
+        'Input lengths mismatch'
+    );
+    invariant(
+        tokenBalances.length === tokenDecimals.length,
+        'Input lengths mismatch'
+    );
+    invariant(
+        tokenBalances.length === tokenPrices.length,
+        'Input lengths mismatch'
+    );
+
+    // All token balances are scaled to 18 decimals
+    const scaledBalances = tokenBalances.map((balance, i) =>
+        parseFixed(balance.toString(), 18 - tokenDecimals[i])
+    );
+
+    let sumWeight = Zero;
+    let sumValue = Zero;
+
+    for (let i = 0; i < tokenBalances.length; i++) {
+        const scaledBalance = scaledBalances[i];
+        const weight = tokenWeights[i];
+        const price = tokenPrices[i];
+
+        // If a token's price is unknown, ignore it. It will be computed at the next step
+        if (price === null) {
+            continue;
+        }
+
+        const value = scaledBalance
+            .mul(parseFixed(price.toFixed(18), 18))
+            .div(ONE);
+        sumValue = sumValue.add(value);
+        sumWeight = sumWeight.add(weight);
+    }
+
+    // Scale the known value of x% of the pool to get value of 100% of the pool.
+    const totalWeight = tokenWeights.reduce(
+        (total: BigNumber, weight) => total.add(weight),
+        Zero
+    );
+    if (sumWeight.gt(0)) {
+        const liquidity = sumValue.mul(totalWeight).div(sumWeight);
+        return formatFixed(liquidity, 18);
+    }
+
+    return '0';
+};

--- a/balancer-js/src/pool-weighted/normalizedWeights.ts
+++ b/balancer-js/src/pool-weighted/normalizedWeights.ts
@@ -10,21 +10,26 @@ const MaxWeightedTokens = 100;
  * @param weights - an array of token weights to be normalized
  * @returns an equivalent set of normalized weights
  */
-export function toNormalizedWeights(weights: BigNumber[]): BigNumber[] {
+export function toNormalizedWeights(weights: BigNumberish[]): BigNumber[] {
     // When the number is exactly equal to the max, normalizing with common inputs
     // leads to a value < 0.01, which reverts. In this case fill in the weights exactly.
     if (weights.length == MaxWeightedTokens) {
         return Array(MaxWeightedTokens).fill(ONE.div(MaxWeightedTokens));
     }
 
-    const sum = weights.reduce((total, weight) => total.add(weight), Zero);
-    if (sum.eq(ONE)) return weights;
+    const sum = weights.reduce(
+        (total: BigNumber, weight) => total.add(weight),
+        Zero
+    );
+    if (sum.eq(ONE)) return weights.map(BigNumber.from);
 
     const normalizedWeights = [];
     let normalizedSum = Zero;
     for (let index = 0; index < weights.length; index++) {
         if (index < weights.length - 1) {
-            normalizedWeights[index] = weights[index].mul(ONE).div(sum);
+            normalizedWeights[index] = BigNumber.from(weights[index])
+                .mul(ONE)
+                .div(sum);
             normalizedSum = normalizedSum.add(normalizedWeights[index]);
         } else {
             normalizedWeights[index] = ONE.sub(normalizedSum);


### PR DESCRIPTION
This PR adds functions to calculate the value of weighted and stable pools. This is essentially the functionality from [this service in the frontend](https://github.com/balancer-labs/frontend-v2/blob/develop/src/services/pool/concerns/liquidity.concern.ts) but using ethers rather than `bnum` and with less reliance on the exact structure of the `prices` object. I've also added a generalised version of the stable pool function to handle metastable pools as we don't calculate these 100% accurately as of today.

I'm happy to shuffle these functions around to match the new style of the sdk more closely as it seems like the `pool-*` directories don't match currently. lmk if anything needs changing.

