### PR TITLE
John/relayer errors

### DIFF
--- a/balancer-js/examples/relayerSwapUnwrap.ts
+++ b/balancer-js/examples/relayerSwapUnwrap.ts
@@ -4,6 +4,7 @@ import { parseFixed } from '@ethersproject/bignumber';
 import { Wallet } from '@ethersproject/wallet';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Contract } from '@ethersproject/contracts';
+import linearPoolAbi from '../src/abi/LinearPool.json';
 
 import {
     BalancerSDK,
@@ -31,13 +32,13 @@ Vault must have approvals for tokens
 */
 async function runRelayerSwapUnwrapExactIn() {
     const config: BalancerSdkConfig = {
-        network: Network.KOVAN,
-        rpcUrl: `https://kovan.infura.io/v3/${process.env.INFURA}`,
+        network: Network.MAINNET,
+        rpcUrl: `https://mainnet.infura.io/v3/${process.env.INFURA}`,
     };
 
     const provider = new JsonRpcProvider(config.rpcUrl);
     const key: any = process.env.TRADER_KEY;
-    const relayerAddress = '0x3C255DE4a73Dd251A33dac2ab927002C964Eb2cB';
+    const relayerAddress = '0xAc9f49eF3ab0BbC929f7b1bb0A17E1Fca5786251';
     const wallet = new Wallet(key, provider);
 
     const balancer = new BalancerSDK(config);
@@ -50,35 +51,33 @@ async function runRelayerSwapUnwrapExactIn() {
         toInternalBalance: false,
     };
 
-    // This is using a helper function to get the up to date rates for the Aave tokens
-    const daiRate = await AaveHelpers.getRate(
-        '0x26575a44755e0aaa969fdda1e4291df22c5624ea',
-        provider
-    );
-    const usdcRate = await AaveHelpers.getRate(
-        '0x26743984e3357eFC59f2fd6C1aFDC310335a61c9',
-        provider
-    );
-    const usdtRate = await AaveHelpers.getRate(
-        '0xbfd9769b061e57e478690299011a028194d66e3c',
-        provider
-    );
+    const bbausd = '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2';
+    const bbadai = '0x804CdB9116a10bB78768D3252355a1b18067bF8f';
+    const bbausdc = '0x9210F1204b5a24742Eba12f710636D76240dF3d0';
+    const bbausdt = '0x2BBf681cC4eb09218BEe85EA2a5d3D13Fa40fC0C';
+    const daiLinearPool = new Contract(bbadai, linearPoolAbi, provider);
+    const usdcLinearPool = new Contract(bbausdc, linearPoolAbi, provider);
+    const usdtLinearPool = new Contract(bbausdt, linearPoolAbi, provider);
+    // This is gets the up to date rates for the Aave tokens
+    const daiRate = await daiLinearPool.getWrappedTokenRate();
+    const usdcRate = await usdcLinearPool.getWrappedTokenRate();
+    const usdtRate = await usdtLinearPool.getWrappedTokenRate();
+
+    console.log(`DAI Rate: ${daiRate.toString()}`);
+    console.log(`USDC Rate: ${usdcRate.toString()}`);
+    console.log(`USDT Rate: ${usdtRate.toString()}`);
 
     const txInfo = await balancer.relayer.swapUnwrapAaveStaticExactIn(
+        [bbausd, bbausd, bbausd],
         [
-            STABAL3PHANTOM.address,
-            STABAL3PHANTOM.address,
-            STABAL3PHANTOM.address,
+            '0x02d60b84491589974263d922d9cc7a3152618ef6', // waDAI
+            '0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de', // waUSDC
+            '0xf8fd466f12e236f4c96f7cce6c79eadb819abf58', // waUSDT
         ],
         [
-            WRAPPED_AAVE_DAI.address,
-            WRAPPED_AAVE_USDC.address,
-            WRAPPED_AAVE_USDT.address,
-        ],
-        [
-            parseFixed('1', 16).toString(),
-            parseFixed('1', 16).toString(),
-            parseFixed('1', 16).toString(),
+            parseFixed('30000000', 18).toString(),
+            parseFixed('30000000', 18).toString(),
+            parseFixed('30000000', 18).toString(),
         ],
         [daiRate, usdcRate, usdtRate],
         funds,
@@ -90,6 +89,9 @@ async function runRelayerSwapUnwrapExactIn() {
         balancerRelayerAbi,
         provider
     );
+
+    console.log(`Unwrapped Amounts Out:`);
+    console.log(txInfo.outputs.amountsOut.toString());
     const tx = await relayerContract
         .connect(wallet)
         .callStatic[txInfo.function](txInfo.params, {
@@ -99,8 +101,6 @@ async function runRelayerSwapUnwrapExactIn() {
 
     console.log(`Swap Deltas:`);
     console.log(defaultAbiCoder.decode(['int256[]'], tx[0]).toString());
-    console.log(`Unwrapped Amounts Out:`);
-    console.log(txInfo.outputs.amountsOut.toString());
 }
 
 /*

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@balancer-labs/sdk",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "JavaScript SDK for interacting with the Balancer Protocol V2",
     "license": "GPL-3.0-only",
     "homepage": "https://github.com/balancer-labs/balancer-sdk/balancer-js#readme",

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -27,6 +27,15 @@
         "generate": "graphql-codegen --config src/subgraph/codegen.yml -r dotenv/config"
     },
     "devDependencies": {
+        "@graphql-codegen/add": "^3.1.0",
+        "@graphql-codegen/cli": "^2.3.0",
+        "@graphql-codegen/introspection": "^2.1.0",
+        "@graphql-codegen/schema-ast": "^2.4.0",
+        "@graphql-codegen/typescript": "2.4.0",
+        "@graphql-codegen/typescript-document-nodes": "^2.2.0",
+        "@graphql-codegen/typescript-graphql-request": "^4.3.0",
+        "@graphql-codegen/typescript-operations": "^2.2.0",
+        "@graphql-codegen/typescript-resolvers": "2.4.1",
         "@rollup/plugin-commonjs": "^21.0.1",
         "@rollup/plugin-json": "^4.1.0",
         "@rollup/plugin-node-resolve": "^13.0.0",
@@ -50,27 +59,18 @@
         "tiny-invariant": "^1.1.0",
         "ts-node": "^10.0.0",
         "typechain": "^5.1.1",
-        "typescript": "^4.0.2",
-        "@graphql-codegen/add": "^3.1.0",
-        "@graphql-codegen/cli": "^2.3.0",
-        "@graphql-codegen/introspection": "^2.1.0",
-        "@graphql-codegen/schema-ast": "^2.4.0",
-        "@graphql-codegen/typescript": "2.4.0",
-        "@graphql-codegen/typescript-document-nodes": "^2.2.0",
-        "@graphql-codegen/typescript-graphql-request": "^4.3.0",
-        "@graphql-codegen/typescript-operations": "^2.2.0",
-        "@graphql-codegen/typescript-resolvers": "2.4.1"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
-        "@balancer-labs/sor": "3.0.0-beta.0",
+        "@balancer-labs/sor": "3.0.0-beta.1",
         "@ethersproject/abi": "^5.5.0",
         "@ethersproject/abstract-signer": "^5.5.0",
         "@ethersproject/contracts": "^5.5.0",
         "@ethersproject/providers": "^5.5.0",
-        "lodash": "^4.17.21",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
-        "graphql-request": "^3.5.0"
+        "graphql-request": "^3.5.0",
+        "lodash": "^4.17.21"
     },
     "peerDependencies": {
         "@ethersproject/abi": "^5.4.0",

--- a/balancer-js/src/swapsService/queryBatchSwap.ts
+++ b/balancer-js/src/swapsService/queryBatchSwap.ts
@@ -65,6 +65,15 @@ export async function queryBatchSwapWithSor(
             queryWithSor.amounts[i].toString(),
             sor
         );
+        if (!swap.returnAmount.gt(Zero))
+            // Throw here because swaps with 0 amounts has no path and has misleading result for query
+            throw new Error(
+                `queryBatchSwapWithSor: SOR Swap returned 0 amount, ${
+                    queryWithSor.tokensIn[i]
+                }>${queryWithSor.tokensOut[i]}: ${queryWithSor.amounts[
+                    i
+                ].toString()}`
+            );
         swaps.push(swap.swaps);
         assetArray.push(swap.tokenAddresses);
     }
@@ -76,8 +85,8 @@ export async function queryBatchSwapWithSor(
         queryWithSor.swapType === SwapType.SwapExactIn
             ? queryWithSor.tokensOut
             : queryWithSor.tokensIn;
-    const returnAmounts: string[] = Array(returnTokens.length).fill(Zero);
-    let deltas: BigNumberish[] = Array(batchedSwaps.assets.length).fill(Zero);
+    const returnAmounts: string[] = Array(returnTokens.length).fill('0');
+    let deltas: BigNumberish[] = Array(batchedSwaps.assets.length).fill('0');
     try {
         // Onchain query
         deltas = await queryBatchSwap(
@@ -97,7 +106,9 @@ export async function queryBatchSwapWithSor(
             );
         }
     } catch (err) {
-        console.error(`queryBatchSwapTokensIn error: ${err}`);
+        throw new Error(
+            `queryBatchSwapWithSor: Error duing onchain query ${err}`
+        );
     }
 
     return {

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -481,10 +481,10 @@
     "@babel/helper-validator-identifier" "^7.15.7"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/sor@3.0.0-beta.0":
-  version "3.0.0-beta.0"
-  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-3.0.0-beta.0.tgz#380f9b85856416305981be740c454965e116dba1"
-  integrity sha512-Yp8FDjj0KJtaxyZIbktRZ1ECyd3THVrzgi32RtPwDeGAqWssbCCR130eAZdtJwm/og6BF7FdwBkbQI9N4J5wyQ==
+"@balancer-labs/sor@3.0.0-beta.1":
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-3.0.0-beta.1.tgz#74d74e2df10cb0390d92aef01efc284025c006af"
+  integrity sha512-mtB6EO/qJj1OSFbMezoQ55ciLv/sCe4oR9i0I3MbfGucMMxkEewOmsy4ZUvMexHteYBto8B+OlY+7MxxigDGjg==
   dependencies:
     "@georgeroman/balancer-v2-pools" "0.0.7"
     isomorphic-fetch "^2.2.1"


### PR DESCRIPTION
- Update SOR. Fixed limit in Linear Pool BPT>wrapped.
- Changed to make Relayer throw errors. SDK should not be handling error cases for consumer but will exit and throw early.
- Updated relayerSwapUnwrap example to use Mainnet as it is more useful.