### PR TITLE
Add pricing module with tests.

### DIFF
--- a/balancer-js/README.md
+++ b/balancer-js/README.md
@@ -165,6 +165,35 @@ swaps.querySimpleFlashSwap(batchSwap: {
 
 [Example](./examples/querySimpleFlashSwap.ts)
 
+## Pricing Module
+
+Exposes Spot Price functionality allowing user to query spot price for token pair.
+
+```js
+const pricing = new Pricing(sdkConfig);
+```
+
+### #getSpotPrice
+
+Calculates Spot Price for a token pair - for specific pool if ID otherwise finds most liquid path and uses this as reference SP.
+
+@param { string } tokenIn Token in address.
+@param { string } tokenOut Token out address.
+@param { string } poolId Optional - if specified this pool will be used for SP calculation.
+@param { SubgraphPoolBase[] } pools Optional - Pool data. Will be fetched via dataProvider if not supplied.
+@returns  { string } Spot price.
+
+```js
+async getSpotPrice(
+    tokenIn: string,
+    tokenOut: string,
+    poolId = '',
+    pools: SubgraphPoolBase[] = []
+): Promise<string>
+```
+
+[Example](./examples/spotPrice.ts)
+
 ## RelayerService
 
 Relayers are (user opt-in, audited) contracts that can make calls to the vault (with the transaction “sender” being any arbitrary address) and use the sender’s ERC20 vault allowance, internal balance or BPTs on their behalf.

--- a/balancer-js/examples/spotPrice.ts
+++ b/balancer-js/examples/spotPrice.ts
@@ -1,0 +1,36 @@
+import dotenv from 'dotenv';
+import {
+    BalancerSDK,
+    Network,
+    BalancerSdkConfig,
+} from '../src/index';
+import { ADDRESSES } from '../src/test/lib/constants';
+
+dotenv.config();
+
+/*
+Example showing how to use SDK to get spot price for a pair.
+*/
+async function getSpotPrice() {
+    const network = Network.MAINNET;
+    const config: BalancerSdkConfig = {
+        network,
+        rpcUrl: `https://mainnet.infura.io/v3/${process.env.INFURA}`,
+    };
+
+    const balancer = new BalancerSDK(config);
+
+    const wethDaiPoolId = '0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a';
+    // This will fetch pools information using data provider
+    const spotPriceEthDai = await balancer.pricing.getSpotPrice(ADDRESSES[network].DAI.address, ADDRESSES[network].WETH.address, wethDaiPoolId);
+    console.log(spotPriceEthDai.toString());
+
+    const balDaiPoolId = '0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011';
+    // Reuses previously fetched pools data
+    const pools = balancer.pricing.getPools();
+    const spotPriceBalDai = await balancer.pricing.getSpotPrice(ADDRESSES[network].DAI.address, ADDRESSES[network].BAL.address, balDaiPoolId, pools);
+    console.log(spotPriceBalDai.toString());
+}
+
+// yarn examples:run ./examples/spotPrice.ts
+getSpotPrice();

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -75,7 +75,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "@balancer-labs/sor": "^4.0.0-beta.2",
+        "@balancer-labs/sor": "/Users/jg/Documents/balancer-sor/balancer-labs-sor-v4.0.0-beta.8.tgz",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
         "graphql-request": "^3.5.0",

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -75,7 +75,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "@balancer-labs/sor": "/Users/jg/Documents/balancer-sor/balancer-labs-sor-v4.0.0-beta.8.tgz",
+        "@balancer-labs/sor": "^4.0.0-beta.5",
         "axios": "^0.24.0",
         "graphql": "^15.6.1",
         "graphql-request": "^3.5.0",

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@balancer-labs/sdk",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "description": "JavaScript SDK for interacting with the Balancer Protocol V2",
     "license": "GPL-3.0-only",
     "homepage": "https://github.com/balancer-labs/balancer-sdk/balancer-js#readme",

--- a/balancer-js/src/balancerErrors.ts
+++ b/balancer-js/src/balancerErrors.ts
@@ -6,6 +6,7 @@ export enum BalancerErrorCode {
     POOL_DOESNT_EXIST = 'POOL_DOESNT_EXIST',
     UNSUPPORTED_POOL_TYPE = 'UNSUPPORTED_POOL_TYPE',
     UNSUPPORTED_PAIR = 'UNSUPPORTED_PAIR',
+    NO_POOL_DATA = 'NO_POOL_DATA',
 }
 
 export class BalancerError extends Error {
@@ -30,6 +31,8 @@ export class BalancerError extends Error {
                 return 'unsupported pool type';
             case BalancerErrorCode.UNSUPPORTED_PAIR:
                 return 'unsupported token pair';
+            case BalancerErrorCode.NO_POOL_DATA:
+                return 'no pool data';
             default:
                 return 'Unknown error';
         }

--- a/balancer-js/src/balancerErrors.ts
+++ b/balancer-js/src/balancerErrors.ts
@@ -3,6 +3,9 @@ export enum BalancerErrorCode {
     UNWRAP_ZERO_AMOUNT = 'UNWRAP_ZERO_AMOUNT',
     WRAP_ZERO_AMOUNT = 'WRAP_ZERO_AMOUNT',
     QUERY_BATCH_SWAP = 'QUERY_BATCH_SWAP',
+    POOL_DOESNT_EXIST = 'POOL_DOESNT_EXIST',
+    UNSUPPORTED_POOL_TYPE = 'UNSUPPORTED_POOL_TYPE',
+    UNSUPPORTED_PAIR = 'UNSUPPORTED_PAIR',
 }
 
 export class BalancerError extends Error {
@@ -21,6 +24,12 @@ export class BalancerError extends Error {
                 return 'swapUnwrapAaveStaticExactOut wrapped amount < 0';
             case BalancerErrorCode.QUERY_BATCH_SWAP:
                 return 'queryBatchSwap on chain call error';
+            case BalancerErrorCode.POOL_DOESNT_EXIST:
+                return 'balancer pool does not exist';
+            case BalancerErrorCode.UNSUPPORTED_POOL_TYPE:
+                return 'unsupported pool type';
+            case BalancerErrorCode.UNSUPPORTED_PAIR:
+                return 'unsupported token pair';
             default:
                 return 'Unknown error';
         }

--- a/balancer-js/src/modules/pools/pool-types/concerns/linear/liquidity.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/linear/liquidity.concern.ts
@@ -1,0 +1,16 @@
+import { LiquidityConcern } from '../types';
+import { BigNumberish } from '@ethersproject/bignumber';
+
+export class LinearPoolLiquidity implements LiquidityConcern {
+    calcTotal(
+        tokenBalances: BigNumberish[],
+        tokenDecimals: number[],
+        tokenPriceRates: BigNumberish[],
+        tokenPrices: (number | null)[]
+    ): string {
+        // TODO implementation
+        console.log(tokenBalances, tokenDecimals, tokenPriceRates, tokenPrices);
+        throw new Error('To be implemented');
+        return '1000';
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/concerns/linear/spotPrice.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/linear/spotPrice.concern.ts
@@ -1,0 +1,16 @@
+import { SpotPriceConcern } from '../types';
+import { SubgraphPoolBase, LinearPool, ZERO } from '@balancer-labs/sor';
+
+export class LinearPoolSpotPrice implements SpotPriceConcern {
+    calcPoolSpotPrice(
+        tokenIn: string,
+        tokenOut: string,
+        pool: SubgraphPoolBase
+    ): string {
+        const poolClass = LinearPool.fromPool(pool);
+        const poolPairData = poolClass.parsePoolPairData(tokenIn, tokenOut);
+        return poolClass
+            ._spotPriceAfterSwapExactTokenInForTokenOut(poolPairData, ZERO)
+            .toString();
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/concerns/metaStable/liquidity.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/metaStable/liquidity.concern.ts
@@ -1,0 +1,16 @@
+import { LiquidityConcern } from '../types';
+import { BigNumberish } from '@ethersproject/bignumber';
+
+export class MetaStablePoolLiquidity implements LiquidityConcern {
+    calcTotal(
+        tokenBalances: BigNumberish[],
+        tokenDecimals: number[],
+        tokenPriceRates: BigNumberish[],
+        tokenPrices: (number | null)[]
+    ): string {
+        // TODO implementation
+        console.log(tokenBalances, tokenDecimals, tokenPriceRates, tokenPrices);
+        throw new Error('To be implemented');
+        return '1000';
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/concerns/metaStable/spotPrice.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/metaStable/spotPrice.concern.ts
@@ -1,0 +1,16 @@
+import { SpotPriceConcern } from '../types';
+import { SubgraphPoolBase, MetaStablePool, ZERO } from '@balancer-labs/sor';
+
+export class MetaStablePoolSpotPrice implements SpotPriceConcern {
+    calcPoolSpotPrice(
+        tokenIn: string,
+        tokenOut: string,
+        pool: SubgraphPoolBase
+    ): string {
+        const poolClass = MetaStablePool.fromPool(pool);
+        const poolPairData = poolClass.parsePoolPairData(tokenIn, tokenOut);
+        return poolClass
+            ._spotPriceAfterSwapExactTokenInForTokenOut(poolPairData, ZERO)
+            .toString();
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/spotPrice.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/spotPrice.concern.ts
@@ -1,0 +1,16 @@
+import { SpotPriceConcern } from '../types';
+import { SubgraphPoolBase, StablePool, ZERO } from '@balancer-labs/sor';
+
+export class StablePoolSpotPrice implements SpotPriceConcern {
+    calcPoolSpotPrice(
+        tokenIn: string,
+        tokenOut: string,
+        pool: SubgraphPoolBase
+    ): string {
+        const poolClass = StablePool.fromPool(pool);
+        const poolPairData = poolClass.parsePoolPairData(tokenIn, tokenOut);
+        return poolClass
+            ._spotPriceAfterSwapExactTokenInForTokenOut(poolPairData, ZERO)
+            .toString();
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/liquidity.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/liquidity.concern.ts
@@ -1,0 +1,16 @@
+import { LiquidityConcern } from '../types';
+import { BigNumberish } from '@ethersproject/bignumber';
+
+export class StablePhantomPoolLiquidity implements LiquidityConcern {
+    calcTotal(
+        tokenBalances: BigNumberish[],
+        tokenDecimals: number[],
+        tokenPriceRates: BigNumberish[],
+        tokenPrices: (number | null)[]
+    ): string {
+        // TODO implementation
+        console.log(tokenBalances, tokenDecimals, tokenPriceRates, tokenPrices);
+        throw new Error('To be implemented');
+        return '1000';
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/spotPrice.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/spotPrice.concern.ts
@@ -1,0 +1,16 @@
+import { SpotPriceConcern } from '../types';
+import { SubgraphPoolBase, PhantomStablePool, ZERO } from '@balancer-labs/sor';
+
+export class StablePhantomPoolSpotPrice implements SpotPriceConcern {
+    calcPoolSpotPrice(
+        tokenIn: string,
+        tokenOut: string,
+        pool: SubgraphPoolBase
+    ): string {
+        const poolClass = PhantomStablePool.fromPool(pool);
+        const poolPairData = poolClass.parsePoolPairData(tokenIn, tokenOut);
+        return poolClass
+            ._spotPriceAfterSwapExactTokenInForTokenOut(poolPairData, ZERO)
+            .toString();
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/concerns/types.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/types.ts
@@ -1,5 +1,15 @@
 /* eslint @typescript-eslint/no-explicit-any: ["error", { "ignoreRestArgs": true }] */
 
+import { SubgraphPoolBase } from '@balancer-labs/sor';
+
 export interface LiquidityConcern {
     calcTotal: (...args: any[]) => string;
+}
+
+export interface SpotPriceConcern {
+    calcPoolSpotPrice: (
+        tokenIn: string,
+        tokenOut: string,
+        pool: SubgraphPoolBase
+    ) => string;
 }

--- a/balancer-js/src/modules/pools/pool-types/concerns/weighted/spotPrice.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/weighted/spotPrice.concern.ts
@@ -1,0 +1,16 @@
+import { SpotPriceConcern } from '../types';
+import { SubgraphPoolBase, WeightedPool, ZERO } from '@balancer-labs/sor';
+
+export class WeightedPoolSpotPrice implements SpotPriceConcern {
+    calcPoolSpotPrice(
+        tokenIn: string,
+        tokenOut: string,
+        pool: SubgraphPoolBase
+    ): string {
+        const weightedPool = WeightedPool.fromPool(pool);
+        const poolPairData = weightedPool.parsePoolPairData(tokenIn, tokenOut);
+        return weightedPool
+            ._spotPriceAfterSwapExactTokenInForTokenOut(poolPairData, ZERO)
+            .toString();
+    }
+}

--- a/balancer-js/src/modules/pools/pool-types/linear.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/linear.module.ts
@@ -1,0 +1,10 @@
+import { LinearPoolLiquidity } from './concerns/linear/liquidity.concern';
+import { LinearPoolSpotPrice } from './concerns/linear/spotPrice.concern';
+import { PoolType } from './pool-type.interface';
+
+export class Linear implements PoolType {
+    constructor(
+        public liquidity = new LinearPoolLiquidity(),
+        public spotPrice = new LinearPoolSpotPrice()
+    ) {}
+}

--- a/balancer-js/src/modules/pools/pool-types/linear.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/linear.module.ts
@@ -1,10 +1,28 @@
+import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { LinearPoolLiquidity } from './concerns/linear/liquidity.concern';
 import { LinearPoolSpotPrice } from './concerns/linear/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 
 export class Linear implements PoolType {
     constructor(
+        public poolData?: SubgraphPoolBase,
         public liquidity = new LinearPoolLiquidity(),
-        public spotPrice = new LinearPoolSpotPrice()
+        public spotPriceConcern = new LinearPoolSpotPrice()
     ) {}
+
+    updateData(poolData: SubgraphPoolBase): void {
+        this.poolData = poolData;
+    }
+
+    spotPrice(tokenIn: string, tokenOut: string): string {
+        if (!this.poolData)
+            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
+
+        return this.spotPriceConcern.calcPoolSpotPrice(
+            tokenIn,
+            tokenOut,
+            this.poolData
+        );
+    }
 }

--- a/balancer-js/src/modules/pools/pool-types/linear.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/linear.module.ts
@@ -1,28 +1,17 @@
-import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { LinearPoolLiquidity } from './concerns/linear/liquidity.concern';
 import { LinearPoolSpotPrice } from './concerns/linear/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
-import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export class Linear implements PoolType {
+    public liquidityCalculator: LiquidityConcern;
+    public spotPriceCalculator: SpotPriceConcern;
+
     constructor(
-        public poolData?: SubgraphPoolBase,
-        public liquidity = new LinearPoolLiquidity(),
-        public spotPriceConcern = new LinearPoolSpotPrice()
-    ) {}
-
-    updateData(poolData: SubgraphPoolBase): void {
-        this.poolData = poolData;
-    }
-
-    spotPrice(tokenIn: string, tokenOut: string): string {
-        if (!this.poolData)
-            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
-
-        return this.spotPriceConcern.calcPoolSpotPrice(
-            tokenIn,
-            tokenOut,
-            this.poolData
-        );
+        private liquidityCalculatorConcern = LinearPoolLiquidity,
+        private spotPriceCalculatorConcern = LinearPoolSpotPrice
+    ) {
+        this.liquidityCalculator = new this.liquidityCalculatorConcern();
+        this.spotPriceCalculator = new this.spotPriceCalculatorConcern();
     }
 }

--- a/balancer-js/src/modules/pools/pool-types/metaStable.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/metaStable.module.ts
@@ -1,10 +1,28 @@
+import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { MetaStablePoolLiquidity } from './concerns/metaStable/liquidity.concern';
 import { MetaStablePoolSpotPrice } from './concerns/metaStable/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 
 export class MetaStable implements PoolType {
     constructor(
+        public poolData?: SubgraphPoolBase,
         public liquidity = new MetaStablePoolLiquidity(),
-        public spotPrice = new MetaStablePoolSpotPrice()
+        public spotPriceConcern = new MetaStablePoolSpotPrice()
     ) {}
+
+    updateData(poolData: SubgraphPoolBase): void {
+        this.poolData = poolData;
+    }
+
+    spotPrice(tokenIn: string, tokenOut: string): string {
+        if (!this.poolData)
+            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
+
+        return this.spotPriceConcern.calcPoolSpotPrice(
+            tokenIn,
+            tokenOut,
+            this.poolData
+        );
+    }
 }

--- a/balancer-js/src/modules/pools/pool-types/metaStable.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/metaStable.module.ts
@@ -1,28 +1,17 @@
-import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { MetaStablePoolLiquidity } from './concerns/metaStable/liquidity.concern';
 import { MetaStablePoolSpotPrice } from './concerns/metaStable/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
-import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export class MetaStable implements PoolType {
+    public liquidityCalculator: LiquidityConcern;
+    public spotPriceCalculator: SpotPriceConcern;
+
     constructor(
-        public poolData?: SubgraphPoolBase,
-        public liquidity = new MetaStablePoolLiquidity(),
-        public spotPriceConcern = new MetaStablePoolSpotPrice()
-    ) {}
-
-    updateData(poolData: SubgraphPoolBase): void {
-        this.poolData = poolData;
-    }
-
-    spotPrice(tokenIn: string, tokenOut: string): string {
-        if (!this.poolData)
-            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
-
-        return this.spotPriceConcern.calcPoolSpotPrice(
-            tokenIn,
-            tokenOut,
-            this.poolData
-        );
+        private liquidityCalculatorConcern = MetaStablePoolLiquidity,
+        private spotPriceCalculatorConcern = MetaStablePoolSpotPrice
+    ) {
+        this.liquidityCalculator = new this.liquidityCalculatorConcern();
+        this.spotPriceCalculator = new this.spotPriceCalculatorConcern();
     }
 }

--- a/balancer-js/src/modules/pools/pool-types/metaStable.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/metaStable.module.ts
@@ -1,0 +1,10 @@
+import { MetaStablePoolLiquidity } from './concerns/metaStable/liquidity.concern';
+import { MetaStablePoolSpotPrice } from './concerns/metaStable/spotPrice.concern';
+import { PoolType } from './pool-type.interface';
+
+export class MetaStable implements PoolType {
+    constructor(
+        public liquidity = new MetaStablePoolLiquidity(),
+        public spotPrice = new MetaStablePoolSpotPrice()
+    ) {}
+}

--- a/balancer-js/src/modules/pools/pool-types/pool-type.interface.ts
+++ b/balancer-js/src/modules/pools/pool-types/pool-type.interface.ts
@@ -1,5 +1,6 @@
-import { LiquidityConcern } from './concerns/types';
+import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export interface PoolType {
     liquidity: LiquidityConcern;
+    spotPrice: SpotPriceConcern;
 }

--- a/balancer-js/src/modules/pools/pool-types/pool-type.interface.ts
+++ b/balancer-js/src/modules/pools/pool-types/pool-type.interface.ts
@@ -1,9 +1,6 @@
-import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export interface PoolType {
-    liquidity: LiquidityConcern;
-    spotPriceConcern: SpotPriceConcern;
-    updateData: (poolData: SubgraphPoolBase) => void;
-    spotPrice: (tokenIn: string, tokenOut: string) => string;
+    liquidityCalculator: LiquidityConcern;
+    spotPriceCalculator: SpotPriceConcern;
 }

--- a/balancer-js/src/modules/pools/pool-types/pool-type.interface.ts
+++ b/balancer-js/src/modules/pools/pool-types/pool-type.interface.ts
@@ -1,6 +1,9 @@
+import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export interface PoolType {
     liquidity: LiquidityConcern;
-    spotPrice: SpotPriceConcern;
+    spotPriceConcern: SpotPriceConcern;
+    updateData: (poolData: SubgraphPoolBase) => void;
+    spotPrice: (tokenIn: string, tokenOut: string) => string;
 }

--- a/balancer-js/src/modules/pools/pool-types/stable.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/stable.module.ts
@@ -1,10 +1,28 @@
+import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { StablePoolLiquidity } from './concerns/stable/liquidity.concern';
 import { StablePoolSpotPrice } from './concerns/stable/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 
 export class Stable implements PoolType {
     constructor(
+        public poolData?: SubgraphPoolBase,
         public liquidity = new StablePoolLiquidity(),
-        public spotPrice = new StablePoolSpotPrice()
+        public spotPriceConcern = new StablePoolSpotPrice()
     ) {}
+
+    updateData(poolData: SubgraphPoolBase): void {
+        this.poolData = poolData;
+    }
+
+    spotPrice(tokenIn: string, tokenOut: string): string {
+        if (!this.poolData)
+            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
+
+        return this.spotPriceConcern.calcPoolSpotPrice(
+            tokenIn,
+            tokenOut,
+            this.poolData
+        );
+    }
 }

--- a/balancer-js/src/modules/pools/pool-types/stable.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/stable.module.ts
@@ -1,6 +1,10 @@
 import { StablePoolLiquidity } from './concerns/stable/liquidity.concern';
+import { StablePoolSpotPrice } from './concerns/stable/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
 
 export class Stable implements PoolType {
-    constructor(public liquidity = new StablePoolLiquidity()) {}
+    constructor(
+        public liquidity = new StablePoolLiquidity(),
+        public spotPrice = new StablePoolSpotPrice()
+    ) {}
 }

--- a/balancer-js/src/modules/pools/pool-types/stable.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/stable.module.ts
@@ -1,28 +1,17 @@
-import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { StablePoolLiquidity } from './concerns/stable/liquidity.concern';
 import { StablePoolSpotPrice } from './concerns/stable/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
-import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export class Stable implements PoolType {
+    public liquidityCalculator: LiquidityConcern;
+    public spotPriceCalculator: SpotPriceConcern;
+
     constructor(
-        public poolData?: SubgraphPoolBase,
-        public liquidity = new StablePoolLiquidity(),
-        public spotPriceConcern = new StablePoolSpotPrice()
-    ) {}
-
-    updateData(poolData: SubgraphPoolBase): void {
-        this.poolData = poolData;
-    }
-
-    spotPrice(tokenIn: string, tokenOut: string): string {
-        if (!this.poolData)
-            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
-
-        return this.spotPriceConcern.calcPoolSpotPrice(
-            tokenIn,
-            tokenOut,
-            this.poolData
-        );
+        private liquidityCalculatorConcern = StablePoolLiquidity,
+        private spotPriceCalculatorConcern = StablePoolSpotPrice
+    ) {
+        this.liquidityCalculator = new this.liquidityCalculatorConcern();
+        this.spotPriceCalculator = new this.spotPriceCalculatorConcern();
     }
 }

--- a/balancer-js/src/modules/pools/pool-types/stablePhantom.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/stablePhantom.module.ts
@@ -1,0 +1,10 @@
+import { StablePhantomPoolLiquidity } from './concerns/stablePhantom/liquidity.concern';
+import { StablePhantomPoolSpotPrice } from './concerns/stablePhantom/spotPrice.concern';
+import { PoolType } from './pool-type.interface';
+
+export class StablePhantom implements PoolType {
+    constructor(
+        public liquidity = new StablePhantomPoolLiquidity(),
+        public spotPrice = new StablePhantomPoolSpotPrice()
+    ) {}
+}

--- a/balancer-js/src/modules/pools/pool-types/stablePhantom.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/stablePhantom.module.ts
@@ -1,10 +1,28 @@
+import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { StablePhantomPoolLiquidity } from './concerns/stablePhantom/liquidity.concern';
 import { StablePhantomPoolSpotPrice } from './concerns/stablePhantom/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 
 export class StablePhantom implements PoolType {
     constructor(
+        public poolData?: SubgraphPoolBase,
         public liquidity = new StablePhantomPoolLiquidity(),
-        public spotPrice = new StablePhantomPoolSpotPrice()
+        public spotPriceConcern = new StablePhantomPoolSpotPrice()
     ) {}
+
+    updateData(poolData: SubgraphPoolBase): void {
+        this.poolData = poolData;
+    }
+
+    spotPrice(tokenIn: string, tokenOut: string): string {
+        if (!this.poolData)
+            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
+
+        return this.spotPriceConcern.calcPoolSpotPrice(
+            tokenIn,
+            tokenOut,
+            this.poolData
+        );
+    }
 }

--- a/balancer-js/src/modules/pools/pool-types/stablePhantom.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/stablePhantom.module.ts
@@ -1,28 +1,17 @@
-import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { StablePhantomPoolLiquidity } from './concerns/stablePhantom/liquidity.concern';
 import { StablePhantomPoolSpotPrice } from './concerns/stablePhantom/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
-import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export class StablePhantom implements PoolType {
+    public liquidityCalculator: LiquidityConcern;
+    public spotPriceCalculator: SpotPriceConcern;
+
     constructor(
-        public poolData?: SubgraphPoolBase,
-        public liquidity = new StablePhantomPoolLiquidity(),
-        public spotPriceConcern = new StablePhantomPoolSpotPrice()
-    ) {}
-
-    updateData(poolData: SubgraphPoolBase): void {
-        this.poolData = poolData;
-    }
-
-    spotPrice(tokenIn: string, tokenOut: string): string {
-        if (!this.poolData)
-            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
-
-        return this.spotPriceConcern.calcPoolSpotPrice(
-            tokenIn,
-            tokenOut,
-            this.poolData
-        );
+        private liquidityCalculatorConcern = StablePhantomPoolLiquidity,
+        private spotPriceCalculatorConcern = StablePhantomPoolSpotPrice
+    ) {
+        this.liquidityCalculator = new this.liquidityCalculatorConcern();
+        this.spotPriceCalculator = new this.spotPriceCalculatorConcern();
     }
 }

--- a/balancer-js/src/modules/pools/pool-types/weighted.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/weighted.module.ts
@@ -1,28 +1,17 @@
-import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { WeightedPoolLiquidity } from './concerns/weighted/liquidity.concern';
 import { WeightedPoolSpotPrice } from './concerns/weighted/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
-import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+import { LiquidityConcern, SpotPriceConcern } from './concerns/types';
 
 export class Weighted implements PoolType {
+    public liquidityCalculator: LiquidityConcern;
+    public spotPriceCalculator: SpotPriceConcern;
+
     constructor(
-        public poolData?: SubgraphPoolBase,
-        public liquidity = new WeightedPoolLiquidity(),
-        public spotPriceConcern = new WeightedPoolSpotPrice()
-    ) {}
-
-    updateData(poolData: SubgraphPoolBase): void {
-        this.poolData = poolData;
-    }
-
-    spotPrice(tokenIn: string, tokenOut: string): string {
-        if (!this.poolData)
-            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
-
-        return this.spotPriceConcern.calcPoolSpotPrice(
-            tokenIn,
-            tokenOut,
-            this.poolData
-        );
+        private liquidityCalculatorConcern = WeightedPoolLiquidity,
+        private spotPriceCalculatorConcern = WeightedPoolSpotPrice
+    ) {
+        this.liquidityCalculator = new this.liquidityCalculatorConcern();
+        this.spotPriceCalculator = new this.spotPriceCalculatorConcern();
     }
 }

--- a/balancer-js/src/modules/pools/pool-types/weighted.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/weighted.module.ts
@@ -1,6 +1,10 @@
 import { WeightedPoolLiquidity } from './concerns/weighted/liquidity.concern';
+import { WeightedPoolSpotPrice } from './concerns/weighted/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
 
 export class Weighted implements PoolType {
-    constructor(public liquidity = new WeightedPoolLiquidity()) {}
+    constructor(
+        public liquidity = new WeightedPoolLiquidity(),
+        public spotPrice = new WeightedPoolSpotPrice()
+    ) {}
 }

--- a/balancer-js/src/modules/pools/pool-types/weighted.module.ts
+++ b/balancer-js/src/modules/pools/pool-types/weighted.module.ts
@@ -1,10 +1,28 @@
+import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { WeightedPoolLiquidity } from './concerns/weighted/liquidity.concern';
 import { WeightedPoolSpotPrice } from './concerns/weighted/spotPrice.concern';
 import { PoolType } from './pool-type.interface';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 
 export class Weighted implements PoolType {
     constructor(
+        public poolData?: SubgraphPoolBase,
         public liquidity = new WeightedPoolLiquidity(),
-        public spotPrice = new WeightedPoolSpotPrice()
+        public spotPriceConcern = new WeightedPoolSpotPrice()
     ) {}
+
+    updateData(poolData: SubgraphPoolBase): void {
+        this.poolData = poolData;
+    }
+
+    spotPrice(tokenIn: string, tokenOut: string): string {
+        if (!this.poolData)
+            throw new BalancerError(BalancerErrorCode.NO_POOL_DATA);
+
+        return this.spotPriceConcern.calcPoolSpotPrice(
+            tokenIn,
+            tokenOut,
+            this.poolData
+        );
+    }
 }

--- a/balancer-js/src/modules/pools/pools.module.ts
+++ b/balancer-js/src/modules/pools/pools.module.ts
@@ -17,33 +17,28 @@ export class Pools {
         public linear = new Linear()
     ) {}
 
-    static find(
-        id: string,
-        pools: SubgraphPoolBase[]
+    static from(
+        pool: SubgraphPoolBase
     ): Weighted | Stable | MetaStable | StablePhantom | Linear {
-        // Find pool of interest from pools list
-        const pool = pools.find((p) => p.id.toLowerCase() === id.toLowerCase());
-        if (!pool) throw new BalancerError(BalancerErrorCode.POOL_DOESNT_EXIST);
-
         // Calculate spot price using pool type
         switch (pool.poolType) {
             case 'Weighted':
             case 'Investment':
             case 'LiquidityBootstrapping': {
-                return new Weighted(pool);
+                return new Weighted();
             }
             case 'Stable': {
-                return new Stable(pool);
+                return new Stable();
             }
             case 'MetaStable': {
-                return new MetaStable(pool);
+                return new MetaStable();
             }
             case 'StablePhantom': {
-                return new StablePhantom(pool);
+                return new StablePhantom();
             }
             case 'AaveLinear':
             case 'ERC4626Linear': {
-                return new Linear(pool);
+                return new Linear();
             }
             default:
                 throw new BalancerError(

--- a/balancer-js/src/modules/pools/pools.module.ts
+++ b/balancer-js/src/modules/pools/pools.module.ts
@@ -1,11 +1,17 @@
 import { BalancerSdkConfig } from '@/types';
 import { Stable } from './pool-types/stable.module';
 import { Weighted } from './pool-types/weighted.module';
+import { MetaStable } from './pool-types/metaStable.module';
+import { StablePhantom } from './pool-types/stablePhantom.module';
+import { Linear } from './pool-types/linear.module';
 
 export class Pools {
     constructor(
         config: BalancerSdkConfig,
         public weighted = new Weighted(),
-        public stable = new Stable()
+        public stable = new Stable(),
+        public metaStable = new MetaStable(),
+        public stablePhantom = new StablePhantom(),
+        public linear = new Linear()
     ) {}
 }

--- a/balancer-js/src/modules/pools/pools.module.ts
+++ b/balancer-js/src/modules/pools/pools.module.ts
@@ -4,6 +4,8 @@ import { Weighted } from './pool-types/weighted.module';
 import { MetaStable } from './pool-types/metaStable.module';
 import { StablePhantom } from './pool-types/stablePhantom.module';
 import { Linear } from './pool-types/linear.module';
+import { SubgraphPoolBase } from '@balancer-labs/sor';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 
 export class Pools {
     constructor(
@@ -14,4 +16,39 @@ export class Pools {
         public stablePhantom = new StablePhantom(),
         public linear = new Linear()
     ) {}
+
+    static find(
+        id: string,
+        pools: SubgraphPoolBase[]
+    ): Weighted | Stable | MetaStable | StablePhantom | Linear {
+        // Find pool of interest from pools list
+        const pool = pools.find((p) => p.id.toLowerCase() === id.toLowerCase());
+        if (!pool) throw new BalancerError(BalancerErrorCode.POOL_DOESNT_EXIST);
+
+        // Calculate spot price using pool type
+        switch (pool.poolType) {
+            case 'Weighted':
+            case 'Investment':
+            case 'LiquidityBootstrapping': {
+                return new Weighted(pool);
+            }
+            case 'Stable': {
+                return new Stable(pool);
+            }
+            case 'MetaStable': {
+                return new MetaStable(pool);
+            }
+            case 'StablePhantom': {
+                return new StablePhantom(pool);
+            }
+            case 'AaveLinear':
+            case 'ERC4626Linear': {
+                return new Linear(pool);
+            }
+            default:
+                throw new BalancerError(
+                    BalancerErrorCode.UNSUPPORTED_POOL_TYPE
+                );
+        }
+    }
 }

--- a/balancer-js/src/modules/pricing/pricing.module.spec.ts
+++ b/balancer-js/src/modules/pricing/pricing.module.spec.ts
@@ -1,0 +1,243 @@
+import dotenv from 'dotenv';
+import { expect } from 'chai';
+import {
+    BalancerSdkConfig,
+    BalancerSdkSorConfig,
+    Network,
+    BalancerSDK,
+} from '@/.';
+import { Pricing } from './pricing.module';
+import { MockPoolDataService } from '@/test/lib/mockPool';
+import { ADDRESSES } from '@/test/lib/constants';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+
+import pools_14717479 from '@/test/lib/pools_14717479.json';
+
+let sdkConfig: BalancerSdkConfig;
+
+dotenv.config();
+
+const weth_usdc_pool_id =
+    '0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019';
+const weth_bal_pool_id =
+    '0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014';
+
+describe('pricing module', () => {
+    before(() => {
+        // Mainnet pool snapshot taken at block 14717479
+        const mockPoolDataService = new MockPoolDataService(
+            pools_14717479 as any
+        );
+
+        const sorConfig: BalancerSdkSorConfig = {
+            tokenPriceService: 'coingecko',
+            poolDataService: mockPoolDataService,
+            fetchOnChainBalances: false,
+        };
+
+        sdkConfig = {
+            network: Network.MAINNET,
+            rpcUrl: ``,
+            sor: sorConfig,
+        };
+    });
+
+    context('instantiation', () => {
+        it('instantiate via module', async () => {
+            const pricing = new Pricing(sdkConfig);
+            await pricing.fetchPools();
+            const pools = pricing.getPools();
+            expect(pools).to.deep.eq(pools_14717479);
+        });
+
+        it('instantiate via SDK', async () => {
+            const balancer = new BalancerSDK(sdkConfig);
+            await balancer.pricing.fetchPools();
+            const pools = balancer.pricing.getPools();
+            expect(pools).to.deep.eq(pools_14717479);
+        });
+    });
+
+    context('spot price for pool', () => {
+        describe('via module', () => {
+            it('should fetch pools from poolDataService if no pools passed as param', async () => {
+                const pricing = new Pricing(sdkConfig);
+                const sp = await pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].WETH.address,
+                    ADDRESSES[Network.MAINNET].USDC.address,
+                    weth_usdc_pool_id
+                );
+                expect(sp).to.deep.eq('0.0003423365526722167');
+            });
+
+            it('should fetch pools from poolDataService if empty pools passed as param', async () => {
+                const pricing = new Pricing(sdkConfig);
+                const sp = await pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].USDC.address,
+                    ADDRESSES[Network.MAINNET].WETH.address,
+                    weth_usdc_pool_id,
+                    []
+                );
+                expect(sp).to.deep.eq('2925.488620398681');
+            });
+
+            it('should throw if poolDataService returns no pools', async () => {
+                const emptyPoolDataService = new MockPoolDataService([]);
+                const sorConfig: BalancerSdkSorConfig = {
+                    tokenPriceService: 'coingecko',
+                    poolDataService: emptyPoolDataService,
+                    fetchOnChainBalances: false,
+                };
+                const sdkConfig: BalancerSdkConfig = {
+                    network: Network.MAINNET,
+                    rpcUrl: ``,
+                    sor: sorConfig,
+                };
+                const balancer = new BalancerSDK(sdkConfig);
+                let error = null;
+                try {
+                    await balancer.pricing.getSpotPrice(
+                        ADDRESSES[Network.MAINNET].WETH.address,
+                        ADDRESSES[Network.MAINNET].USDC.address,
+                        weth_usdc_pool_id
+                    );
+                } catch (err) {
+                    error = err.message;
+                }
+                expect(error).to.eq(
+                    BalancerError.getMessage(
+                        BalancerErrorCode.POOL_DOESNT_EXIST
+                    )
+                );
+            });
+
+            it('should throw with unsupported pool type', async () => {
+                const nonValidPool = { ...(pools_14717479[0] as any) };
+                nonValidPool.poolType = 'UnsupportedPool';
+
+                const balancer = new BalancerSDK(sdkConfig);
+                let error = null;
+                try {
+                    await balancer.pricing.getSpotPrice(
+                        ADDRESSES[Network.MAINNET].WETH.address,
+                        ADDRESSES[Network.MAINNET].BAL.address,
+                        pools_14717479[0].id,
+                        [nonValidPool]
+                    );
+                } catch (err) {
+                    error = err.message;
+                }
+                expect(error).to.eq(
+                    BalancerError.getMessage(
+                        BalancerErrorCode.UNSUPPORTED_POOL_TYPE
+                    )
+                );
+            });
+        });
+        describe('via SDK', () => {
+            it('should fetch pools with no pools data param', async () => {
+                const balancer = new BalancerSDK(sdkConfig);
+                const sp = await balancer.pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].WETH.address,
+                    ADDRESSES[Network.MAINNET].BAL.address,
+                    weth_bal_pool_id
+                );
+                expect(sp).to.deep.eq('0.004981212133448337');
+            });
+        });
+    });
+
+    context('spot price without pool - finds most liquid path', () => {
+        describe('via module', () => {
+            it('should throw for pair with no liquidity', async () => {
+                let error = null;
+                try {
+                    const pricing = new Pricing(sdkConfig);
+                    await pricing.getSpotPrice('', '');
+                } catch (err) {
+                    error = err.message;
+                }
+                expect(error).to.eq(
+                    BalancerError.getMessage(BalancerErrorCode.UNSUPPORTED_PAIR)
+                );
+            });
+
+            it('should fetch pools with no pools data param', async () => {
+                const pricing = new Pricing(sdkConfig);
+                const sp = await pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].WETH.address,
+                    ADDRESSES[Network.MAINNET].USDC.address
+                );
+                expect(sp).to.deep.eq('0.0003423365526722167');
+            });
+
+            it('should fetch pools with no pools data param', async () => {
+                const pricing = new Pricing(sdkConfig);
+                const sp = await pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].USDC.address,
+                    ADDRESSES[Network.MAINNET].WETH.address
+                );
+                expect(sp).to.deep.eq('2925.488620398681');
+            });
+        });
+
+        describe('via SDK', () => {
+            it('should fetch pools with no pools data param', async () => {
+                const balancer = new BalancerSDK(sdkConfig);
+                const sp = await balancer.pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].WETH.address,
+                    ADDRESSES[Network.MAINNET].USDC.address
+                );
+                expect(sp).to.deep.eq('0.0003423365526722167');
+            });
+        });
+
+        describe('stable pool', () => {
+            it('should fetch correct sp', async () => {
+                const balancer = new BalancerSDK(sdkConfig);
+                const sp = await balancer.pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].DAI.address,
+                    ADDRESSES[Network.MAINNET].USDC.address,
+                    '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063'
+                );
+                expect(sp).to.deep.eq('1.000051911328148725');
+            });
+        });
+
+        describe('metastable pool', () => {
+            it('should fetch correct sp', async () => {
+                const balancer = new BalancerSDK(sdkConfig);
+                const sp = await balancer.pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].WETH.address,
+                    ADDRESSES[Network.MAINNET].wSTETH.address,
+                    '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080'
+                );
+                expect(sp).to.deep.eq('1.070497605163895290828158545877174735');
+            });
+        });
+
+        describe('phantomstable pool', () => {
+            it('should fetch correct sp', async () => {
+                const balancer = new BalancerSDK(sdkConfig);
+                const sp = await balancer.pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].bbausd.address,
+                    ADDRESSES[Network.MAINNET].bbausdc.address,
+                    '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe'
+                );
+                expect(sp).to.deep.eq('0.997873677414938406552928560423740375');
+            });
+        });
+
+        describe('linear pool', () => {
+            it('should fetch correct sp', async () => {
+                const balancer = new BalancerSDK(sdkConfig);
+                const sp = await balancer.pricing.getSpotPrice(
+                    ADDRESSES[Network.MAINNET].USDC.address,
+                    ADDRESSES[Network.MAINNET].bbausdc.address,
+                    '0x9210f1204b5a24742eba12f710636d76240df3d00000000000000000000000fc'
+                );
+                expect(sp).to.deep.eq('1.008078200925769181');
+            });
+        });
+    });
+});

--- a/balancer-js/src/modules/pricing/pricing.module.spec.ts
+++ b/balancer-js/src/modules/pricing/pricing.module.spec.ts
@@ -102,6 +102,7 @@ describe('pricing module', () => {
                         ADDRESSES[Network.MAINNET].USDC.address,
                         weth_usdc_pool_id
                     );
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 } catch (err: any) {
                     error = err.message;
                 }
@@ -126,6 +127,7 @@ describe('pricing module', () => {
                         pools_14717479[0].id,
                         [nonValidPool]
                     );
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 } catch (err: any) {
                     error = err.message;
                 }
@@ -156,6 +158,7 @@ describe('pricing module', () => {
                 try {
                     const pricing = new Pricing(sdkConfig);
                     await pricing.getSpotPrice('', '');
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 } catch (err: any) {
                     error = err.message;
                 }

--- a/balancer-js/src/modules/pricing/pricing.module.spec.ts
+++ b/balancer-js/src/modules/pricing/pricing.module.spec.ts
@@ -101,7 +101,7 @@ describe('pricing module', () => {
                         ADDRESSES[Network.MAINNET].USDC.address,
                         weth_usdc_pool_id
                     );
-                } catch (err) {
+                } catch (err: any) {
                     error = err.message;
                 }
                 expect(error).to.eq(
@@ -124,7 +124,7 @@ describe('pricing module', () => {
                         pools_14717479[0].id,
                         [nonValidPool]
                     );
-                } catch (err) {
+                } catch (err: any) {
                     error = err.message;
                 }
                 expect(error).to.eq(
@@ -154,7 +154,7 @@ describe('pricing module', () => {
                 try {
                     const pricing = new Pricing(sdkConfig);
                     await pricing.getSpotPrice('', '');
-                } catch (err) {
+                } catch (err: any) {
                     error = err.message;
                 }
                 expect(error).to.eq(

--- a/balancer-js/src/modules/pricing/pricing.module.ts
+++ b/balancer-js/src/modules/pricing/pricing.module.ts
@@ -76,8 +76,17 @@ export class Pricing {
             return getSpotPriceAfterSwapForPath(paths[0], 0, ZERO).toString();
         } else {
             // Find pool of interest from pools list
-            const pool = Pools.find(poolId, pools);
-            return pool.spotPrice(tokenIn, tokenOut);
+            const poolData = pools.find(
+                (p) => p.id.toLowerCase() === poolId.toLowerCase()
+            );
+            if (!poolData)
+                throw new BalancerError(BalancerErrorCode.POOL_DOESNT_EXIST);
+            const pool = Pools.from(poolData);
+            return pool.spotPriceCalculator.calcPoolSpotPrice(
+                tokenIn,
+                tokenOut,
+                poolData
+            );
         }
     }
 }

--- a/balancer-js/src/modules/pricing/pricing.module.ts
+++ b/balancer-js/src/modules/pricing/pricing.module.ts
@@ -76,57 +76,8 @@ export class Pricing {
             return getSpotPriceAfterSwapForPath(paths[0], 0, ZERO).toString();
         } else {
             // Find pool of interest from pools list
-            const pool = pools.find(
-                (p) => p.id.toLowerCase() === poolId.toLowerCase()
-            );
-            if (!pool)
-                throw new BalancerError(BalancerErrorCode.POOL_DOESNT_EXIST);
-
-            // Calculate spot price using pool type
-            switch (pool.poolType) {
-                case 'Weighted':
-                case 'Investment':
-                case 'LiquidityBootstrapping': {
-                    return this.pools.weighted.spotPrice.calcPoolSpotPrice(
-                        tokenIn,
-                        tokenOut,
-                        pool
-                    );
-                }
-                case 'Stable': {
-                    return this.pools.stable.spotPrice.calcPoolSpotPrice(
-                        tokenIn,
-                        tokenOut,
-                        pool
-                    );
-                }
-                case 'MetaStable': {
-                    return this.pools.metaStable.spotPrice.calcPoolSpotPrice(
-                        tokenIn,
-                        tokenOut,
-                        pool
-                    );
-                }
-                case 'StablePhantom': {
-                    return this.pools.stablePhantom.spotPrice.calcPoolSpotPrice(
-                        tokenIn,
-                        tokenOut,
-                        pool
-                    );
-                }
-                case 'AaveLinear':
-                case 'ERC4626Linear': {
-                    return this.pools.linear.spotPrice.calcPoolSpotPrice(
-                        tokenIn,
-                        tokenOut,
-                        pool
-                    );
-                }
-                default:
-                    throw new BalancerError(
-                        BalancerErrorCode.UNSUPPORTED_POOL_TYPE
-                    );
-            }
+            const pool = Pools.find(poolId, pools);
+            return pool.spotPrice(tokenIn, tokenOut);
         }
     }
 }

--- a/balancer-js/src/modules/pricing/pricing.module.ts
+++ b/balancer-js/src/modules/pricing/pricing.module.ts
@@ -1,0 +1,157 @@
+import { Swaps } from '@/modules/swaps/swaps.module';
+import { BalancerSdkConfig } from '@/types';
+import {
+    SubgraphPoolBase,
+    WeightedPool,
+    StablePool,
+    MetaStablePool,
+    PhantomStablePool,
+    ZERO,
+    parseToPoolsDict,
+    getSpotPriceAfterSwapForPath,
+    LinearPool,
+} from '@balancer-labs/sor';
+import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+
+export class Pricing {
+    private readonly swaps: Swaps;
+
+    constructor(swapsOrConfig: Swaps | BalancerSdkConfig) {
+        if (swapsOrConfig instanceof Swaps) {
+            this.swaps = swapsOrConfig;
+        } else {
+            this.swaps = new Swaps(swapsOrConfig);
+        }
+    }
+
+    /**
+     * Retrieves pools using poolDataService.
+     * @returns {boolean} Boolean indicating whether pools data was fetched correctly (true) or not (false).
+     */
+    async fetchPools(): Promise<boolean> {
+        return this.swaps.fetchPools();
+    }
+
+    /**
+     * Get currently saved pools list (fetched using fetchPools()).
+     * @returns {SubgraphPoolBase[]} pools list.
+     */
+    public getPools(): SubgraphPoolBase[] {
+        return this.swaps.getPools();
+    }
+
+    /**
+     * Calculate Spot Price for token pair in specific  pool.
+     * @param {WeightedPool | StablePool | PhantomStablePool | LinearPool} pool Pool instance.
+     * @param { string } tokenIn Token in address.
+     * @param { string } tokenOut Token out address.
+     * @returns  { string } Spot price.
+     */
+    private calculatePoolSpotPrice(
+        pool: WeightedPool | StablePool | PhantomStablePool | LinearPool,
+        tokenIn: string,
+        tokenOut: string
+    ): string {
+        const poolPairData: any = pool.parsePoolPairData(tokenIn, tokenOut);
+        return pool
+            ._spotPriceAfterSwapExactTokenInForTokenOut(poolPairData, ZERO)
+            .toString();
+    }
+
+    /**
+     * Calculates Spot Price for a token pair - for specific pool if ID otherwise finds most liquid path and uses this as reference SP.
+     * @param { string } tokenIn Token in address.
+     * @param { string } tokenOut Token out address.
+     * @param { string } poolId Optional - if specified this pool will be used for SP calculation.
+     * @param { SubgraphPoolBase[] } pools Optional - Pool data. Will be fetched via dataProvider if not supplied.
+     * @returns  { string } Spot price.
+     */
+    async getSpotPrice(
+        tokenIn: string,
+        tokenOut: string,
+        poolId = '',
+        pools: SubgraphPoolBase[] = []
+    ): Promise<string> {
+        // If pools list isn't supplied fetch it from swaps data provider
+        if (pools.length === 0) {
+            await this.fetchPools();
+            pools = this.getPools();
+        }
+
+        // If a poolId isn't specified we find the path for the pair with the highest liquidity and use this as the ref SP
+        if (poolId === '') {
+            const poolsDict = parseToPoolsDict(pools, 0);
+            // This creates all paths for tokenIn>Out ordered by liquidity
+            const paths =
+                this.swaps.sor.routeProposer.getCandidatePathsFromDict(
+                    tokenIn,
+                    tokenOut,
+                    0,
+                    poolsDict,
+                    4
+                );
+
+            if (paths.length === 0)
+                throw new BalancerError(BalancerErrorCode.UNSUPPORTED_PAIR);
+            return getSpotPriceAfterSwapForPath(paths[0], 0, ZERO).toString();
+        } else {
+            // Find pool of interest from pools list
+            const pool = pools.find(
+                (p) => p.id.toLowerCase() === poolId.toLowerCase()
+            );
+            if (!pool)
+                throw new BalancerError(BalancerErrorCode.POOL_DOESNT_EXIST);
+
+            // Calculate spot price using pool type
+            switch (pool.poolType) {
+                case 'Weighted':
+                case 'Investment':
+                case 'LiquidityBootstrapping': {
+                    const weightedPool = WeightedPool.fromPool(pool);
+                    return this.calculatePoolSpotPrice(
+                        weightedPool,
+                        tokenIn,
+                        tokenOut
+                    );
+                }
+                case 'Stable': {
+                    const stablePool = StablePool.fromPool(pool);
+                    return this.calculatePoolSpotPrice(
+                        stablePool,
+                        tokenIn,
+                        tokenOut
+                    );
+                }
+                case 'MetaStable': {
+                    const metaStablePool = MetaStablePool.fromPool(pool);
+                    return this.calculatePoolSpotPrice(
+                        metaStablePool,
+                        tokenIn,
+                        tokenOut
+                    );
+                }
+                case 'StablePhantom': {
+                    const stablePool = PhantomStablePool.fromPool(pool);
+                    return this.calculatePoolSpotPrice(
+                        stablePool,
+                        tokenIn,
+                        tokenOut
+                    );
+                }
+                case 'AaveLinear':
+                case 'ERC4626Linear': {
+                    const linearPool = LinearPool.fromPool(pool);
+                    return this.calculatePoolSpotPrice(
+                        linearPool,
+                        tokenIn,
+                        tokenOut
+                    );
+                }
+                default:
+                    throw new BalancerError(
+                        BalancerErrorCode.UNSUPPORTED_POOL_TYPE
+                    );
+            }
+        }
+    }
+}

--- a/balancer-js/src/modules/sdk.module.ts
+++ b/balancer-js/src/modules/sdk.module.ts
@@ -5,10 +5,12 @@ import { Subgraph } from './subgraph/subgraph.module';
 import { Sor } from './sor/sor.module';
 import { getNetworkConfig } from './sdk.helpers';
 import { Pools } from './pools/pools.module';
+import { Pricing } from './pricing/pricing.module';
 
 export class BalancerSDK {
     public readonly swaps: Swaps;
     public readonly relayer: Relayer;
+    public readonly pricing: Pricing;
 
     constructor(
         public config: BalancerSdkConfig,
@@ -18,6 +20,7 @@ export class BalancerSDK {
     ) {
         this.swaps = new Swaps(this.sor);
         this.relayer = new Relayer(this.swaps);
+        this.pricing = new Pricing(this.swaps);
     }
 
     public get networkConfig(): BalancerNetworkConfig {

--- a/balancer-js/src/modules/sdk.module.ts
+++ b/balancer-js/src/modules/sdk.module.ts
@@ -20,7 +20,7 @@ export class BalancerSDK {
     ) {
         this.swaps = new Swaps(this.sor);
         this.relayer = new Relayer(this.swaps);
-        this.pricing = new Pricing(this.swaps);
+        this.pricing = new Pricing(config, this.swaps);
     }
 
     public get networkConfig(): BalancerNetworkConfig {

--- a/balancer-js/src/modules/swaps/queryBatchSwap.ts
+++ b/balancer-js/src/modules/swaps/queryBatchSwap.ts
@@ -117,7 +117,7 @@ export async function queryBatchSwapWithSor(
 Use SOR to get swapInfo for tokenIn>tokenOut.
 SwapInfos.swaps has path information.
 */
-async function getSorSwapInfo(
+export async function getSorSwapInfo(
     tokenIn: string,
     tokenOut: string,
     swapType: SwapType,

--- a/balancer-js/src/modules/swaps/swaps.module.ts
+++ b/balancer-js/src/modules/swaps/swaps.module.ts
@@ -1,5 +1,5 @@
 import { Contract } from '@ethersproject/contracts';
-import { SOR, SubgraphPoolBase } from '@balancer-labs/sor';
+import { SOR, SubgraphPoolBase, SwapInfo } from '@balancer-labs/sor';
 import {
     BatchSwap,
     QuerySimpleFlashSwapParameters,
@@ -9,11 +9,16 @@ import {
     SimpleFlashSwapParameters,
     SwapType,
 } from './types';
-import { queryBatchSwap, queryBatchSwapWithSor } from './queryBatchSwap';
+import {
+    queryBatchSwap,
+    queryBatchSwapWithSor,
+    getSorSwapInfo,
+} from './queryBatchSwap';
 import { balancerVault } from '@/lib/constants/config';
 import { getLimitsForSlippage } from './helpers';
 import vaultAbi from '@/lib/abi/Vault.json';
 import { BalancerSdkConfig } from '@/types';
+import { SwapInput } from './types';
 import { Sor } from '@/modules/sor/sor.module';
 import {
     convertSimpleFlashSwapToBatchSwapParameters,
@@ -22,7 +27,7 @@ import {
 import { Interface } from '@ethersproject/abi';
 
 export class Swaps {
-    private readonly sor: SOR;
+    readonly sor: SOR;
 
     constructor(sorOrConfig: SOR | BalancerSdkConfig) {
         if (sorOrConfig instanceof SOR) {
@@ -206,5 +211,24 @@ export class Swaps {
             ...params,
             vaultContract,
         });
+    }
+
+    /**
+     * Use SOR to get swapInfo for tokenIn<>tokenOut.
+     * @param {SwapInput} swapInput - Swap information used for querying using SOR.
+     * @param {string} swapInput.tokenIn - Addresse of asset in.
+     * @param {string} swapInput.tokenOut - Addresse of asset out.
+     * @param {SwapType} swapInput.swapType - Type of Swap, ExactIn/Out.
+     * @param {string} swapInput.amount - Amount used in swap.
+     * @returns {Promise<SwapInfo>} SOR swap info.
+     */
+    async getSorSwap(swapInput: SwapInput): Promise<SwapInfo> {
+        return await getSorSwapInfo(
+            swapInput.tokenIn,
+            swapInput.tokenOut,
+            swapInput.swapType,
+            swapInput.amount,
+            this.sor
+        );
     }
 }

--- a/balancer-js/src/modules/swaps/types.ts
+++ b/balancer-js/src/modules/swaps/types.ts
@@ -59,6 +59,13 @@ export interface QueryWithSorInput {
     fetchPools: FetchPoolsInput;
 }
 
+export interface SwapInput {
+    tokenIn: string;
+    tokenOut: string;
+    swapType: SwapType;
+    amount: string;
+}
+
 export interface QueryWithSorOutput {
     returnAmounts: string[];
     swaps: BatchSwapStep[];

--- a/balancer-js/src/test/lib/constants.ts
+++ b/balancer-js/src/test/lib/constants.ts
@@ -1,0 +1,250 @@
+import { Network } from '@/lib/constants/network';
+import { AddressZero } from '@ethersproject/constants';
+
+export const ADDRESSES = {
+    [Network.MAINNET]: {
+        BatchRelayer: {
+            address: '0xdcdbf71A870cc60C6F9B621E28a7D3Ffd6Dd4965',
+        },
+        ETH: {
+            address: AddressZero,
+            decimals: 18,
+            symbol: 'ETH',
+        },
+        BAL: {
+            address: '0xba100000625a3754423978a60c9317c58a424e3d',
+            decimals: 18,
+            symbol: 'BAL',
+        },
+        USDC: {
+            address: '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+            decimals: 6,
+            symbol: 'USDC',
+        },
+        WBTC: {
+            address: '0x2260fac5e5542a773aa44fbcfedf7c193bc2c599',
+            decimals: 8,
+            symbol: 'WBTC',
+        },
+        WETH: {
+            address: '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2',
+            decimals: 18,
+            symbol: 'WETH',
+        },
+        DAI: {
+            address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+            decimals: 18,
+            symbol: 'DAI',
+        },
+        STETH: {
+            address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
+            decimals: 18,
+            symbol: 'STETH',
+        },
+        wSTETH: {
+            address: '0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0',
+            decimals: 18,
+            symbol: 'wSTETH',
+        },
+        bbausd: {
+            address: '0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2',
+            decimals: 18,
+            symbol: 'bbausd',
+        },
+        bbausdc: {
+            address: '0x9210F1204b5a24742Eba12f710636D76240dF3d0',
+            decimals: 18,
+            symbol: 'bbausdc',
+        },
+        waDAI: {
+            address: '0x02d60b84491589974263d922d9cc7a3152618ef6',
+            decimals: 18,
+            symbol: 'waDAI',
+        },
+        waUSDC: {
+            address: '0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de',
+            decimals: 6,
+            symbol: 'waUSDC',
+        },
+    },
+    [Network.KOVAN]: {
+        // Visit https://balancer-faucet.on.fleek.co/#/faucet for test tokens
+        BatchRelayer: {
+            address: '0x41B953164995c11C81DA73D212ED8Af25741b7Ac',
+        },
+        ETH: {
+            address: AddressZero,
+            decimals: 18,
+            symbol: 'ETH',
+        },
+        BAL: {
+            address: '0x41286Bb1D3E870f3F750eB7E1C25d7E48c8A1Ac7',
+            decimals: 18,
+            symbol: 'BAL',
+        },
+        USDC: {
+            address: '0xc2569dd7d0fd715B054fBf16E75B001E5c0C1115',
+            decimals: 6,
+            symbol: 'USDC',
+        },
+        WBTC: {
+            address: '0x1C8E3Bcb3378a443CC591f154c5CE0EBb4dA9648',
+            decimals: 8,
+            symbol: 'WBTC',
+        },
+        WETH: {
+            address: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+            decimals: 18,
+            symbol: 'WETH',
+        },
+        DAI: {
+            address: '0x04DF6e4121c27713ED22341E7c7Df330F56f289B',
+            decimals: 18,
+            symbol: 'DAI',
+        },
+        STETH: {
+            address: '0x4803bb90d18a1cb7a2187344fe4feb0e07878d05',
+            decimals: 18,
+            symbol: 'STETH',
+        },
+        wSTETH: {
+            address: '0xa387b91e393cfb9356a460370842bc8dbb2f29af',
+            decimals: 18,
+            symbol: 'wSTETH',
+        },
+        USDT_from_AAVE: {
+            address: '0x13512979ade267ab5100878e2e0f485b568328a4',
+            decimals: 6,
+            symbol: 'USDT_from_AAVE',
+        },
+        aUSDT: {
+            address: '0xe8191aacfcdb32260cda25830dc6c9342142f310',
+            decimals: 6,
+            symbol: 'aUSDT',
+        },
+        bUSDT: {
+            address: '0xe667d48618e71c2a02e4a1b66ed9def1426938b6',
+            decimals: 18,
+            symbol: 'bUSDT',
+        },
+        USDC_from_AAVE: {
+            address: '0xe22da380ee6b445bb8273c81944adeb6e8450422',
+            decimals: 6,
+            symbol: 'USDC_from_AAVE',
+        },
+        aUSDC: {
+            address: '0x0fbddc06a4720408a2f5eb78e62bc31ac6e2a3c4',
+            decimals: 6,
+            symbol: 'aUSDC',
+        },
+        DAI_from_AAVE: {
+            address: '0xff795577d9ac8bd7d90ee22b6c1703490b6512fd',
+            decimals: 18,
+            symbol: 'DAI_from_AAVE',
+        },
+        bDAI: {
+            address: '0xfcccb77a946b6a3bd59d149f083b5bfbb8004d6d',
+            decimals: 18,
+            symbol: 'bDAI',
+        },
+        STABAL3: {
+            address: '0x8fd162f338b770f7e879030830cde9173367f301',
+            decimals: 18,
+            symbol: 'STABAL3',
+        },
+    },
+    [Network.POLYGON]: {
+        MATIC: {
+            address: AddressZero,
+            decimals: 18,
+            symbol: 'MATIC',
+        },
+        LINK: {
+            address: '0x53E0bca35eC356BD5ddDFebbD1Fc0fD03FaBad39',
+            decimals: 18,
+            symbol: 'LINK',
+        },
+        BAL: {
+            address: '0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3',
+            decimals: 18,
+            symbol: 'BAL',
+        },
+        USDC: {
+            address: '0x2791bca1f2de4661ed88a30c99a7a9449aa84174',
+            decimals: 6,
+            symbol: 'USDC',
+        },
+        WBTC: {
+            address: '0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6',
+            decimals: 8,
+            symbol: 'WBTC',
+        },
+        WETH: {
+            address: '0x7ceb23fd6bc0add59e62ac25578270cff1b9f619',
+            decimals: 18,
+            symbol: 'WETH',
+        },
+        DAI: {
+            address: '0x8f3cf7ad23cd3cadbd9735aff958023239c6a063',
+            decimals: 18,
+            symbol: 'DAI',
+        },
+        STETH: {
+            address: '0xae7ab96520de3a18e5e111b5eaab095312d7fe84',
+            decimals: 18,
+            symbol: 'STETH',
+        },
+        stUSD_PLUS: {
+            address: '0x5a5c6aa6164750b530b8f7658b827163b3549a4d',
+            decimals: 6,
+            symbol: 'stUSD+',
+        },
+        bstUSD_PLUS: {
+            address: '0x1aafc31091d93c3ff003cff5d2d8f7ba2e728425',
+            decimals: 18,
+            symbol: 'bstUSD+',
+        },
+        USD_PLUS: {
+            address: '0x5d9d8509c522a47d9285b9e4e9ec686e6a580850',
+            decimals: 6,
+            symbol: 'USD_PLUS',
+        },
+        USDT: {
+            address: '0xc2132D05D31c914a87C6611C10748AEb04B58e8F',
+            decimals: 6,
+            symbol: 'USDT',
+        },
+        DHT: {
+            address: '0x8C92e38eCA8210f4fcBf17F0951b198Dd7668292',
+            decimals: 18,
+            symbol: 'DHT',
+        },
+        dUSD: {
+            address: '0xbAe28251B2a4E621aA7e20538c06DEe010Bc06DE',
+            decimals: 18,
+            symbol: 'dUSD',
+        },
+    },
+    [Network.ARBITRUM]: {
+        WETH: {
+            address: '0x82af49447d8a07e3bd95bd0d56f35241523fbab1',
+            decimals: 18,
+            symbol: 'WETH',
+        },
+        BAL: {
+            address: '0x040d1edc9569d4bab2d15287dc5a4f10f56a56b8',
+            decimals: 18,
+            symbol: 'BAL',
+        },
+        USDC: {
+            address: '0xff970a61a04b1ca14834a43f5de4533ebddb5cc8',
+            decimals: 6,
+            symbol: 'USDC',
+        },
+        STETH: {
+            address: 'N/A',
+            decimals: 18,
+            symbol: 'STETH',
+        },
+    },
+};

--- a/balancer-js/src/test/lib/pools_14717479.json
+++ b/balancer-js/src/test/lib/pools_14717479.json
@@ -1,0 +1,15786 @@
+[
+    {
+        "id": "0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080",
+        "address": "0x32296969ef14eb0c6d29669c550d4a0449130230",
+        "poolType": "MetaStable",
+        "swapFee": "0.0004",
+        "totalShares": "169687.103280656830002475",
+        "tokens": [
+            {
+                "address": "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+                "balance": "81391.348751687990895314",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.070274551073343913"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "85441.00300268083736699",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7f39c581f595b53c5cb19bd0b3f8da6c935e2ca0",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "0",
+        "amp": "50.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb20000000000000000000000fe",
+        "address": "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2",
+        "poolType": "StablePhantom",
+        "swapFee": "0.00001",
+        "totalShares": "258465221.870438505937581948",
+        "tokens": [
+            {
+                "address": "0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c",
+                "balance": "83119182.140696356914040574",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.009463810379453854"
+            },
+            {
+                "address": "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2",
+                "balance": "5192296600069605.758091990391638147",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x804cdb9116a10bb78768d3252355a1b18067bf8f",
+                "balance": "85184289.658705251901248874",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.007744303541784998"
+            },
+            {
+                "address": "0x9210f1204b5a24742eba12f710636d76240df3d0",
+                "balance": "90627700.301510239768188246",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.008075205230934721"
+            }
+        ],
+        "tokensList": [
+            "0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c",
+            "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2",
+            "0x804cdb9116a10bb78768d3252355a1b18067bf8f",
+            "0x9210f1204b5a24742eba12f710636d76240df3d0"
+        ],
+        "totalWeight": "0",
+        "amp": "1472.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063",
+        "address": "0x06df3b2bbb68adc8b0e302443692037ed9f91b42",
+        "poolType": "Stable",
+        "swapFee": "0.00005",
+        "totalShares": "187538635.395316740775471172",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "62987016.29199810394001584",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "61515992.969774",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "64118165.731857",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        ],
+        "totalWeight": "0",
+        "amp": "1390.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa6f548df93de924d73be7d25dc02554c6bd66db500020000000000000000000e",
+        "address": "0xa6f548df93de924d73be7d25dc02554c6bd66db5",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "16557.063135200192940751",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "2288.49991019",
+                "decimals": 8,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "30905.537480046675245815",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8000200000000000000000019",
+        "address": "0x96646936b91d6b9d7d0c47c496afbf3d6ec7b6f8",
+        "poolType": "Weighted",
+        "swapFee": "0.00075",
+        "totalShares": "2426107.84135595179965295",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "72492025.092769",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "24798.057464011501273657",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56000200000000000000000014",
+        "address": "0x5c6ee304399dbdb9c8ef030ab642b10820db8f56",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "3575293.223147152615172059",
+        "tokens": [
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "6889567.593728423369471505",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "8493.803428792888641007",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x90291319f1d4ea3ad4db0dd8fe9e12baf749e84500020000000000000000013c",
+        "address": "0x90291319f1d4ea3ad4db0dd8fe9e12baf749e845",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "400273.372346462012791959",
+        "tokens": [
+            {
+                "address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+                "balance": "29668400.474579752851369239",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "23653.738802753224622089",
+                "decimals": 18,
+                "weight": "0.7",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9210f1204b5a24742eba12f710636d76240df3d00000000000000000000000fc",
+        "address": "0x9210f1204b5a24742eba12f710636d76240df3d0",
+        "poolType": "AaveLinear",
+        "swapFee": "0.0002",
+        "totalShares": "90627796.127192247740869246",
+        "tokens": [
+            {
+                "address": "0x9210f1204b5a24742eba12f710636d76240df3d0",
+                "balance": "5192296767907031.501338248588350849",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "2900000.0",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de",
+                "balance": "82331317.336834",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1.074438118266225033"
+            }
+        ],
+        "tokensList": [
+            "0x9210f1204b5a24742eba12f710636d76240df3d0",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 2,
+        "mainIndex": 1,
+        "lowerTarget": "2900000.0",
+        "upperTarget": "10000000.0"
+    },
+    {
+        "id": "0x804cdb9116a10bb78768d3252355a1b18067bf8f0000000000000000000000fb",
+        "address": "0x804cdb9116a10bb78768d3252355a1b18067bf8f",
+        "poolType": "AaveLinear",
+        "swapFee": "0.0002",
+        "totalShares": "85184338.954710017140033196",
+        "tokens": [
+            {
+                "address": "0x02d60b84491589974263d922d9cc7a3152618ef6",
+                "balance": "77733488.610106933510403082",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.071025392251319738"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "2589867.165723702196495923",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x804cdb9116a10bb78768d3252355a1b18067bf8f",
+                "balance": "5192296773350488.673820479189186899",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x02d60b84491589974263d922d9cc7a3152618ef6",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x804cdb9116a10bb78768d3252355a1b18067bf8f"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 1,
+        "lowerTarget": "2900000.0",
+        "upperTarget": "10000000.0"
+    },
+    {
+        "id": "0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c0000000000000000000000fd",
+        "address": "0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c",
+        "poolType": "AaveLinear",
+        "swapFee": "0.0002",
+        "totalShares": "83119187.980364622148449957",
+        "tokens": [
+            {
+                "address": "0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c",
+                "balance": "5192296775415639.648165874180770138",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "2605332.010734",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf8fd466f12e236f4c96f7cce6c79eadb819abf58",
+                "balance": "74842018.079378",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1.086299440697768775"
+            }
+        ],
+        "tokensList": [
+            "0x2bbf681cc4eb09218bee85ea2a5d3d13fa40fc0c",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "0xf8fd466f12e236f4c96f7cce6c79eadb819abf58"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 2,
+        "mainIndex": 1,
+        "lowerTarget": "2900000.0",
+        "upperTarget": "10000000.0"
+    },
+    {
+        "id": "0x0b09dea16768f0799065c475be02919503cb2a3500020000000000000000001a",
+        "address": "0x0b09dea16768f0799065c475be02919503cb2a35",
+        "poolType": "Weighted",
+        "swapFee": "0.0005",
+        "totalShares": "493190.018664242833132025",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "24447747.739925354763240627",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "12524.045637905842316282",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x186084ff790c65088ba694df11758fae4943ee9e000200000000000000000013",
+        "address": "0x186084ff790c65088ba694df11758fae4943ee9e",
+        "poolType": "Weighted",
+        "swapFee": "0.0075",
+        "totalShares": "7329.589964609617024375",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "1508.980343279312815002",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "9320.35028053427530977",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf4c0dd9b82da36c07605df83c8a416f11724d88b000200000000000000000026",
+        "address": "0xf4c0dd9b82da36c07605df83c8a416f11724d88b",
+        "poolType": "Weighted",
+        "swapFee": "0.0075",
+        "totalShares": "116031.140603643597108685",
+        "tokens": [
+            {
+                "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+                "balance": "120565.666150824378404813",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "3282.725843092267967471",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6810e776880c02933d47db1b9fc05908e5386b96",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1e19cf2d73a72ef1332c882f20534b6519be0276000200000000000000000112",
+        "address": "0x1e19cf2d73a72ef1332c882f20534b6519be0276",
+        "poolType": "MetaStable",
+        "swapFee": "0.0004",
+        "totalShares": "6677.622573555497503475",
+        "tokens": [
+            {
+                "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+                "balance": "3177.203294644313257486",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.02353050149022524"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "3476.826256075660973983",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xae78736cd615f374d3085123a210448e74fc6393",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "0",
+        "amp": "50.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56000000000000000000000066",
+        "address": "0xfeadd389a5c427952d8fdb8057d6c8ba1156cc56",
+        "poolType": "Stable",
+        "swapFee": "0.0002",
+        "totalShares": "477.628262078418160973",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "95.81994538",
+                "decimals": 8,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+                "balance": "110.22027675",
+                "decimals": 8,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6",
+                "balance": "273.38241124054932731",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
+            "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6"
+        ],
+        "totalWeight": "0",
+        "amp": "605.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x072f14b85add63488ddad88f855fda4a99d6ac9b000200000000000000000027",
+        "address": "0x072f14b85add63488ddad88f855fda4a99d6ac9b",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "133024.745818427377153805",
+        "tokens": [
+            {
+                "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                "balance": "1710810.01057921100512575",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "2983.462237301397060906",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc065798f227b49c150bcdc6cdc43149a12c4d75700020000000000000000010b",
+        "address": "0xc065798f227b49c150bcdc6cdc43149a12c4d757",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.005",
+        "totalShares": "36815633080869.823028415262249208",
+        "tokens": [
+            {
+                "address": "0x3301ee63fb29f863f2333bd4466acb46cd8323e6",
+                "balance": "17164591669906.160479613340899515",
+                "decimals": 18,
+                "weight": "0.618156596184906959",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "2236.389556882011610737",
+                "decimals": 18,
+                "weight": "0.381858662981477498",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x3301ee63fb29f863f2333bd4466acb46cd8323e6",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x231e687c9961d3a27e6e266ac5c433ce4f8253e4000200000000000000000023",
+        "address": "0x231e687c9961d3a27e6e266ac5c433ce4f8253e4",
+        "poolType": "Weighted",
+        "swapFee": "0.0022",
+        "totalShares": "210610.55335988720129831",
+        "tokens": [
+            {
+                "address": "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
+                "balance": "4167056.800485",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "2835.242643278996839745",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x476c5e26a75bd202a9683ffd34359c0cc15be0ff",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xbf96189eee9357a95c7719f4f5047f76bde804e5000200000000000000000087",
+        "address": "0xbf96189eee9357a95c7719f4f5047f76bde804e5",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "1441560.772955436709816182",
+        "tokens": [
+            {
+                "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+                "balance": "3847671.46722419580432619",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "1022.215884380795005591",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc45d42f801105e861e86658648e3678ad7aa70f900010000000000000000011e",
+        "address": "0xc45d42f801105e861e86658648e3678ad7aa70f9",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "298681.586807706691062017",
+        "tokens": [
+            {
+                "address": "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+                "balance": "236111.652170152",
+                "decimals": 9,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "2285690.738508805467990488",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "786.928290506437476634",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x64aa3364f17a4d01c6f1751fd97c2bd3d7e7f1d5",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe99481dc77691d8e2456e5f3f61c1810adfc1503000200000000000000000018",
+        "address": "0xe99481dc77691d8e2456e5f3f61c1810adfc1503",
+        "poolType": "Weighted",
+        "swapFee": "0.0027",
+        "totalShares": "38856.335146369421895498",
+        "tokens": [
+            {
+                "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+                "balance": "310708.581383836906496952",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "1269.943251897120899209",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x514f35a92a13bc7093f299af5d8ebb1387e42d6b0002000000000000000000c9",
+        "address": "0x514f35a92a13bc7093f299af5d8ebb1387e42d6b",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "6011793.050715525884524572",
+        "tokens": [
+            {
+                "address": "0xa36fdbbae3c9d55a1d67ee5821d53b50b63a1ab9",
+                "balance": "30269723.84643827317647292",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "299.650538259907597272",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa36fdbbae3c9d55a1d67ee5821d53b50b63a1ab9",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5122e01d819e58bb2e22528c0d68d310f0aa6fd7000200000000000000000163",
+        "address": "0x5122e01d819e58bb2e22528c0d68d310f0aa6fd7",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "1228880.501498073160469698",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "298.545433439417658679",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5",
+                "balance": "4158027.07550296",
+                "decimals": 8,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0bf37157d30dfe6f56757dcadff01aed83b08cd600020000000000000000019a",
+        "address": "0x0bf37157d30dfe6f56757dcadff01aed83b08cd6",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "1825.098910837326180338",
+        "tokens": [
+            {
+                "address": "0x333a4823466879eef910a04d473505da62142069",
+                "balance": "1357.517918170487990317",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "278.967609438281353196",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x333a4823466879eef910a04d473505da62142069",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce00020000000000000000001b",
+        "address": "0xaac98ee71d4f8a156b6abaa6844cdb7789d086ce",
+        "poolType": "Weighted",
+        "swapFee": "0.0026",
+        "totalShares": "2031.157027862740676316",
+        "tokens": [
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "1586.812212078115406465",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "540.223641794033323702",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xde8c195aa41c11a0c4787372defbbddaa31306d2000200000000000000000181",
+        "address": "0xde8c195aa41c11a0c4787372defbbddaa31306d2",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "122936.413922215310435943",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "648.081945931269807393",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                "balance": "6136833.642415136887059041",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7edde0cb05ed19e03a9a47cd5e53fc57fde1c80c0002000000000000000000c8",
+        "address": "0x7edde0cb05ed19e03a9a47cd5e53fc57fde1c80c",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "3629147.639457718843226525",
+        "tokens": [
+            {
+                "address": "0x52c9886d5d87b0f06ebacbeff750b5ffad5d17d9",
+                "balance": "2421678.574191",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "1226618.455567",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x52c9886d5d87b0f06ebacbeff750b5ffad5d17d9",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1651253068",
+        "unitSeconds": "778194436",
+        "principalToken": "0x52c9886d5d87b0f06ebacbeff750b5ffad5d17d9",
+        "baseToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xefaa1604e82e1b3af8430b90192c1b9e8197e377000200000000000000000021",
+        "address": "0xefaa1604e82e1b3af8430b90192c1b9e8197e377",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "5865.780802883542740054",
+        "tokens": [
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "15127.642511530592184407",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "593.170088963324476519",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a00020000000000000000004b",
+        "address": "0xa02e4b3d18d4e6b8d18ac421fbc3dfff8933c40a",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "50005.080600846055862344",
+        "tokens": [
+            {
+                "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+                "balance": "1294793.558312818097239898",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "509.526601644163273888",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4bd6d86debdb9f5413e631ad386c4427dc9d01b20002000000000000000000ec",
+        "address": "0x4bd6d86debdb9f5413e631ad386c4427dc9d01b2",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "77.820770710066934429",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "18.47910813",
+                "decimals": 8,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x49e9e169f0b661ea0a883f490564f4cc275123ed",
+                "balance": "59.64160426",
+                "decimals": 8,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x49e9e169f0b661ea0a883f490564f4cc275123ed"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1651265241",
+        "unitSeconds": "2333952170",
+        "principalToken": "0x49e9e169f0b661ea0a883f490564f4cc275123ed",
+        "baseToken": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x27c9f71cc31464b906e0006d4fcbc8900f48f15f00020000000000000000010f",
+        "address": "0x27c9f71cc31464b906e0006d4fcbc8900f48f15f",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "6657341.512650755068007825",
+        "tokens": [
+            {
+                "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+                "balance": "5327202.576143324464755592",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "526164.951163",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01000200000000000000000015",
+        "address": "0xec60a5fef79a92c741cb74fdd6bfc340c0279b01",
+        "poolType": "Weighted",
+        "swapFee": "0.0029",
+        "totalShares": "74744.419132439400504569",
+        "tokens": [
+            {
+                "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+                "balance": "3828777.177324897746308541",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "396.266251447500252114",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x408e41876cccdc0f92210600ef50372656052a38",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xccf5575570fac94cec733a58ff91bb3d073085c70002000000000000000000af",
+        "address": "0xccf5575570fac94cec733a58ff91bb3d073085c7",
+        "poolType": "Investment",
+        "swapFee": "0.006899999999999999",
+        "totalShares": "2520.557447375596899751",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "235.564142452467406724",
+                "decimals": 18,
+                "weight": "0.300000000116415322",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb",
+                "balance": "42548.315672191312548219",
+                "decimals": 18,
+                "weight": "0.700000000116415322",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb"
+        ],
+        "totalWeight": "1.000000000232830645",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe2469f47ab58cf9cf59f9822e3c5de4950a41c49000200000000000000000089",
+        "address": "0xe2469f47ab58cf9cf59f9822e3c5de4950a41c49",
+        "poolType": "Weighted",
+        "swapFee": "0.0041",
+        "totalShares": "1211464.299978290973193769",
+        "tokens": [
+            {
+                "address": "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
+                "balance": "5027081.135370916567784323",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "146.335504361760261104",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa3bed4e1c75d00fa6f4e5e6922db7261b5e9acd2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb39362c3d5ac235fe588b0b83ed7ac87241039cb000100000000000000000195",
+        "address": "0xb39362c3d5ac235fe588b0b83ed7ac87241039cb",
+        "poolType": "Weighted",
+        "swapFee": "0.1",
+        "totalShares": "27970.747017676133550308",
+        "tokens": [
+            {
+                "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+                "balance": "200867.459091087675191171",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "198.059172009417445785",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+                "balance": "38349.931637573908055556",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd33526068d116ce69f19a9ee46f0bd304f21a51f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xefdc9246e0c4280fb1c138e1093a95ab88959cf80002000000000000000000b9",
+        "address": "0xefdc9246e0c4280fb1c138e1093a95ab88959cf8",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "28773.118130186248843266",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "103.59899639364252146",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+                "balance": "52411.391967236529234296",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf5aaf7ee8c39b651cebf5f1f50c10631e78e0ef9000200000000000000000069",
+        "address": "0xf5aaf7ee8c39b651cebf5f1f50c10631e78e0ef9",
+        "poolType": "Weighted",
+        "swapFee": "0.004",
+        "totalShares": "610745.050294619376185288",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "133858.963886164676922763",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "753865.987692",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x350196326aeaa9b98f1903fb5e8fc2686f85318c000200000000000000000084",
+        "address": "0x350196326aeaa9b98f1903fb5e8fc2686f85318c",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "196243.933930418465314007",
+        "tokens": [
+            {
+                "address": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+                "balance": "566968.268460232252813694",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "97.039463860582998361",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5d6e3d7632d6719e04ca162be652164bec1eaa6b000200000000000000000048",
+        "address": "0x5d6e3d7632d6719e04ca162be652164bec1eaa6b",
+        "poolType": "Weighted",
+        "swapFee": "0.0004",
+        "totalShares": "1328886.392243794958245161",
+        "tokens": [
+            {
+                "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+                "balance": "650440.442769438126945985",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "692836.536999",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1050f901a307e7e71471ca3d12dfcea01d0a0a1c00020000000000000000004c",
+        "address": "0x1050f901a307e7e71471ca3d12dfcea01d0a0a1c",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "278413.543969603035481201",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "89.731176958140574588",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+                "balance": "886473.181456129927687412",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0b6a810796de16e5de613ddf19af7249ba398ab00002000000000000000001a2",
+        "address": "0x0b6a810796de16e5de613ddf19af7249ba398ab0",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "399129604968.942959599680645992",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "713965.446359",
+                "decimals": 6,
+                "weight": "0.564801938165417869",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb53ecf1345cabee6ea1a65100ebb153cebcac40f",
+                "balance": "74701263835.424336764827178083",
+                "decimals": 18,
+                "weight": "0.43521332095750164",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xb53ecf1345cabee6ea1a65100ebb153cebcac40f"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x17ddd9646a69c9445cd8a9f921d4cd93bf50d108000200000000000000000159",
+        "address": "0x17ddd9646a69c9445cd8a9f921d4cd93bf50d108",
+        "poolType": "Weighted",
+        "swapFee": "0.0042",
+        "totalShares": "40198.651534664657898375",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "84.915345310741975975",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+                "balance": "78902.183451262828405048",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf2051511b9b121394fa75b8f7d4e7424337af687"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x065e51b8786d8031645e8871aac0e1386f50ea38000200000000000000000139",
+        "address": "0x065e51b8786d8031645e8871aac0e1386f50ea38",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "40129295.367569916265959614",
+        "tokens": [
+            {
+                "address": "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
+                "balance": "447871089.189241626576691697",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "81.803138987760509964",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x3affcca64c2a6f4e3b6bd9c64cd2c969efd1ecbe",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d00020000000000000000008a",
+        "address": "0xbaeec99c90e3420ec6c1e7a769d2a856d2898e4d",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "15456.289526842273347226",
+        "tokens": [
+            {
+                "address": "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+                "balance": "305148.328019987811299405",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "210.081114586093264918",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x81f8f0bb1cb2a06649e51913a151f0e7ef6fa321",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8f4205e1604133d1875a3e771ae7e4f2b086563900020000000000000000010e",
+        "address": "0x8f4205e1604133d1875a3e771ae7e4f2b0865639",
+        "poolType": "Weighted",
+        "swapFee": "0.025",
+        "totalShares": "499686.530895039442510929",
+        "tokens": [
+            {
+                "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+                "balance": "1514960.433892077671070978",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "43085.078481980365585238",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xedf085f65b4f6c155e13155502ef925c9a756003000200000000000000000123",
+        "address": "0xedf085f65b4f6c155e13155502ef925c9a756003",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "892369.646756734631136634",
+        "tokens": [
+            {
+                "address": "0x2c72692e94e757679289ac85d3556b2c0f717e0e",
+                "balance": "363782.459608033905420493",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "530670.986887813926546416",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2c72692e94e757679289ac85d3556b2c0f717e0e",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1651275535",
+        "unitSeconds": "1000355378",
+        "principalToken": "0x2c72692e94e757679289ac85d3556b2c0f717e0e",
+        "baseToken": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3ebf48cd7586d7a4521ce59e53d9a907ebf1480f000200000000000000000028",
+        "address": "0x3ebf48cd7586d7a4521ce59e53d9a907ebf1480f",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "4228.167022816439905271",
+        "tokens": [
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "30319.601299989514780796",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "148.947621733089448222",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x96ba9025311e2f47b840a1f68ed57a3df1ea8747000200000000000000000160",
+        "address": "0x96ba9025311e2f47b840a1f68ed57a3df1ea8747",
+        "poolType": "Weighted",
+        "swapFee": "0.05",
+        "totalShares": "4150974.280519915684914344",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "162770.057788608022650863",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050",
+                "balance": "3970354.292680724125067743",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x87165b659ba7746907a48763063efa3b323c2b0700020000000000000000002d",
+        "address": "0x87165b659ba7746907a48763063efa3b323c2b07",
+        "poolType": "Weighted",
+        "swapFee": "0.0061",
+        "totalShares": "2317437.90986174023419837",
+        "tokens": [
+            {
+                "address": "0x2d94aa3e47d9d5024503ca8491fce9a2fb4da198",
+                "balance": "15990297.960899936194529422",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "49.823945187339053062",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2d94aa3e47d9d5024503ca8491fce9a2fb4da198",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5f7fa48d765053f8dd85e052843e12d23e3d7bc50002000000000000000000c0",
+        "address": "0x5f7fa48d765053f8dd85e052843e12d23e3d7bc5",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "12615.847137835662746482",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "114.389228536077830001",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5",
+                "balance": "403002.45322376",
+                "decimals": 8,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xcfeaead4947f0705a14ec42ac3d44129e1ef3ed5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x01abc00e86c7e258823b9a055fd62ca6cf61a16300010000000000000000003b",
+        "address": "0x01abc00e86c7e258823b9a055fd62ca6cf61a163",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "4681.815284332409594302",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "5.212415607076726028",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "11816.082316143116633027",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+                "balance": "36759.193133411701400271",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "601.439469192360768908",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "62.391637686678700565",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "6575.609743245397799217",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "821.784715867750634773",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "31.962790581968227685",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9137f3a026fa419a7a9a0ba8df6601d4b0abfd260002000000000000000001ab",
+        "address": "0x9137f3a026fa419a7a9a0ba8df6601d4b0abfd26",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "135994.67761794745549497",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "41.277134186457929554",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf17e65822b568b3903685a7c9f496cf7656cc6c2",
+                "balance": "433493.26298353940742073",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf17e65822b568b3903685a7c9f496cf7656cc6c2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x93ab2afded588a9e7f3ef569834b13685d612f96000200000000000000000095",
+        "address": "0x93ab2afded588a9e7f3ef569834b13685d612f96",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "43254098.924896745860640506",
+        "tokens": [
+            {
+                "address": "0x965d79f1a1016b574a62986e13ca8ab04dfdd15c",
+                "balance": "603836447.978486737029212936",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "40.498683939871742394",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x965d79f1a1016b574a62986e13ca8ab04dfdd15c",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe8cc7e765647625b95f59c15848379d10b9ab4af0002000000000000000001de",
+        "address": "0xe8cc7e765647625b95f59c15848379d10b9ab4af",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "218038.559217268011630028",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "38.236802997268975525",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf203ca1769ca8e9e8fe1da9d147db68b6c919817",
+                "balance": "796695.606247211775520001",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf203ca1769ca8e9e8fe1da9d147db68b6c919817"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x92a6a387add0528463b69efc063708870483986a0002000000000000000001cf",
+        "address": "0x92a6a387add0528463b69efc063708870483986a",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "109466.32973929299815839",
+        "tokens": [
+            {
+                "address": "0x0146714490ae3c9b1c4b68d96b4c6a1ba0f38949",
+                "balance": "56000.0",
+                "decimals": 6,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "5948.408198",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0146714490ae3c9b1c4b68d96b4c6a1ba0f38949",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xff083f57a556bfb3bbe46ea1b4fa154b2b1fbe88000200000000000000000030",
+        "address": "0xff083f57a556bfb3bbe46ea1b4fa154b2b1fbe88",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "30983.543533554046514865",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "32.50410974257118772",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+                "balance": "74728.587590796776583546",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x702605f43471183158938c1a3e5f5a359d7b31ba00020000000000000000009f",
+        "address": "0x702605f43471183158938c1a3e5f5a359d7b31ba",
+        "poolType": "Weighted",
+        "swapFee": "0.0039",
+        "totalShares": "69875.969945826088036326",
+        "tokens": [
+            {
+                "address": "0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7",
+                "balance": "211676.395355881136225359",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "28.742296406911155398",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x3ec8798b81485a254928b70cda1cf0a2bb0b74d7",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa7ff759dbef9f3efdd1d59beee44b966acafe214000200000000000000000180",
+        "address": "0xa7ff759dbef9f3efdd1d59beee44b966acafe214",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "396705.921795401726666172",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "77381.442214",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf",
+                "balance": "252947.575704898689242761",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf36bd4ec8127f508f2cd7a00bbb054703e7c70e70002000000000000000001df",
+        "address": "0xf36bd4ec8127f508f2cd7a00bbb054703e7c70e7",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.03",
+        "totalShares": "554631826521.089565146952822536",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "3750.263872",
+                "decimals": 6,
+                "weight": "0.01000991836565064",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb940fd6455b51f8a19e827e70748e1dbd9f3d4c8",
+                "balance": "333094763500.150202683672060068",
+                "decimals": 18,
+                "weight": "0.990005340797886412",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xb940fd6455b51f8a19e827e70748e1dbd9f3d4c8"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x10a2f8bd81ee2898d7ed18fb8f114034a549fa59000200000000000000000090",
+        "address": "0x10a2f8bd81ee2898d7ed18fb8f114034a549fa59",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "367567.946626893569687308",
+        "tokens": [
+            {
+                "address": "0x8a2228705ec979961f0e16df311debcf097a2766",
+                "balance": "150466.24426",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "219130.039959",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8a2228705ec979961f0e16df311debcf097a2766",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1643382476",
+        "unitSeconds": "779456714",
+        "principalToken": "0x8a2228705ec979961f0e16df311debcf097a2766",
+        "baseToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7819f1532c49388106f7762328c51ee70edd134c000200000000000000000109",
+        "address": "0x7819f1532c49388106f7762328c51ee70edd134c",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "282851.490882220767557165",
+        "tokens": [
+            {
+                "address": "0x900db999074d9277c5da2a43f252d74366230da0",
+                "balance": "1233576.490228755350048084",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "24.941358029835441891",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x900db999074d9277c5da2a43f252d74366230da0",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x2d344a84bac123660b021eebe4eb6f12ba25fe8600020000000000000000018a",
+        "address": "0x2d344a84bac123660b021eebe4eb6f12ba25fe86",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "796814.359969985149408849",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "23.469849826862425609",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed1480d12be41d92f36f5f7bdd88212e381a3677",
+                "balance": "4632011.474862245280288637",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xed1480d12be41d92f36f5f7bdd88212e381a3677"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9f1f16b025f703ee985b58ced48daf93dad2f7ef00020000000000000000001e",
+        "address": "0x9f1f16b025f703ee985b58ced48daf93dad2f7ef",
+        "poolType": "Weighted",
+        "swapFee": "0.0006",
+        "totalShares": "391.207490113918570024",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "3.73337019",
+                "decimals": 8,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "10317.903044840001854084",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6dec8d0496590521c8f4f1dee7cfe9c7a6b7a4800002000000000000000001d5",
+        "address": "0x6dec8d0496590521c8f4f1dee7cfe9c7a6b7a480",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "1318130329435.657441972695196922",
+        "tokens": [
+            {
+                "address": "0x57b5920a4c057c6206589b03656f933e24e97f1c",
+                "balance": "800000000000.0",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "3381.565904",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x57b5920a4c057c6206589b03656f933e24e97f1c",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa47d1251cf21ad42685cc6b8b3a186a73dbd06cf000200000000000000000097",
+        "address": "0xa47d1251cf21ad42685cc6b8b3a186a73dbd06cf",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "186128.117730022424798851",
+        "tokens": [
+            {
+                "address": "0x449d7c2e096e9f867339078535b15440d42f78e8",
+                "balance": "65938.680938439530618386",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "120731.833609975164809171",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x449d7c2e096e9f867339078535b15440d42f78e8",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1643382446",
+        "unitSeconds": "778194436",
+        "principalToken": "0x449d7c2e096e9f867339078535b15440d42f78e8",
+        "baseToken": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d00020000000000000000011a",
+        "address": "0xcb0e14e96f2cefa8550ad8e4aea344f211e5061d",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "388840.568721922560122443",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "12.487478329041164605",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xcafe001067cdef266afb7eb5a286dcfd277f3de5",
+                "balance": "2178102.812856225352811974",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xcafe001067cdef266afb7eb5a286dcfd277f3de5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d6520002000000000000000000b5",
+        "address": "0x90ca5cef5b29342b229fb8ae2db5d8f4f894d652",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "178454.128445535066035142",
+        "tokens": [
+            {
+                "address": "0x76a34d72b9cf97d972fb0e390eb053a37f211c74",
+                "balance": "161220.020062",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "17703.638451",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x76a34d72b9cf97d972fb0e390eb053a37f211c74",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1639727861",
+        "unitSeconds": "778194436",
+        "principalToken": "0x76a34d72b9cf97d972fb0e390eb053a37f211c74",
+        "baseToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4626d81b3a1711beb79f4cecff2413886d461677000200000000000000000011",
+        "address": "0x4626d81b3a1711beb79f4cecff2413886d461677",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "48319.526969319763925942",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "95974.852355003603676882",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "6731.378144027931974633",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe7b1d394f3b40abeaa0b64a545dbcf89da1ecb3f00010000000000000000009a",
+        "address": "0xe7b1d394f3b40abeaa0b64a545dbcf89da1ecb3f",
+        "poolType": "Investment",
+        "swapFee": "0.005",
+        "totalShares": "33684.317496411554325903",
+        "tokens": [
+            {
+                "address": "0x123151402076fc819b7564510989e475c9cd93ca",
+                "balance": "93.34620384",
+                "decimals": 8,
+                "weight": "0.150000000174622983",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.19008536",
+                "decimals": 8,
+                "weight": "0.050000000058207661",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+                "balance": "49018.576053540849316293",
+                "decimals": 18,
+                "weight": "0.350000000174622983",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "59096.170472",
+                "decimals": 6,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "2.581808243497129544",
+                "decimals": 18,
+                "weight": "0.050000000058207661",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x123151402076fc819b7564510989e475c9cd93ca",
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000000000465661288",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9243a28616810485173a0ef832fdbc631a042be80002000000000000000001e4",
+        "address": "0x9243a28616810485173a0ef832fdbc631a042be8",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "696640436362284.973129408556721606",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "18616.625312",
+                "decimals": 6,
+                "weight": "0.171985164841768063",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb60f18ac3e782bca69142532e142c2c385a9a5c8",
+                "balance": "377686993784143.630668002583627532",
+                "decimals": 18,
+                "weight": "0.828030094374479614",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xb60f18ac3e782bca69142532e142c2c385a9a5c8"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x51735bdfbfe3fc13dea8dc6502e2e958989429610002000000000000000000a0",
+        "address": "0x51735bdfbfe3fc13dea8dc6502e2e95898942961",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "6422281.000205446027479654",
+        "tokens": [
+            {
+                "address": "0x226f7b842e0f0120b7e194d05432b3fd14773a9d",
+                "balance": "79593595.367921801364701031",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "8.878070516161294751",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x226f7b842e0f0120b7e194d05432b3fd14773a9d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x844ba71d4902ed3de091112951b9c4b4d25a09dd00020000000000000000014b",
+        "address": "0x844ba71d4902ed3de091112951b9c4b4d25a09dd",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "19901.768942019145080232",
+        "tokens": [
+            {
+                "address": "0x92915c346287ddfbcec8f86c8eb52280ed05b3a3",
+                "balance": "23689.015503903452571384",
+                "decimals": 18,
+                "weight": "0.9",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "4.220060152095674697",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x92915c346287ddfbcec8f86c8eb52280ed05b3a3",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xea39581977325c0833694d51656316ef8a926a62000200000000000000000036",
+        "address": "0xea39581977325c0833694d51656316ef8a926a62",
+        "poolType": "Weighted",
+        "swapFee": "0.004",
+        "totalShares": "26538.250182098781995501",
+        "tokens": [
+            {
+                "address": "0x1cf0f3aabe4d12106b27ab44df5473974279c524",
+                "balance": "152321.22152151888626963",
+                "decimals": 18,
+                "weight": "0.75",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "9.09391385777870176",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1cf0f3aabe4d12106b27ab44df5473974279c524",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb460daa847c45f1c4a41cb05bfb3b51c92e41b36000200000000000000000194",
+        "address": "0xb460daa847c45f1c4a41cb05bfb3b51c92e41b36",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "3069.874020936217209792",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.55999199",
+                "decimals": 8,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3472a5a71965499acd81997a54bba8d852c6e53d",
+                "balance": "11109.703953772095130801",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x3472a5a71965499acd81997a54bba8d852c6e53d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32000200000000000000000052",
+        "address": "0x3e5fa9518ea95c3e533eb377c001702a9aacaa32",
+        "poolType": "Weighted",
+        "swapFee": "0.0009",
+        "totalShares": "1832.010643316705333202",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "17.573919029769107128",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "51536.668352",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8e9690e135005e415bd050b11768615de43fe5f8000200000000000000000043",
+        "address": "0x8e9690e135005e415bd050b11768615de43fe5f8",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "14328.966623003421392952",
+        "tokens": [
+            {
+                "address": "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
+                "balance": "2954454.174976918349973674",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "17.686444236251220897",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x11c1a6b3ed6bb362954b29d3183cfa97a0c806aa",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4db9024fc9f477134e00da0da3c77de98d9836ac000200000000000000000086",
+        "address": "0x4db9024fc9f477134e00da0da3c77de98d9836ac",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "2.239086416411365328",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "2.10936064",
+                "decimals": 8,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6bf924137e769c0a5c443dce6ec885552d31d579",
+                "balance": "0.13417987",
+                "decimals": 8,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x6bf924137e769c0a5c443dce6ec885552d31d579"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1637941844",
+        "unitSeconds": "1000355378",
+        "principalToken": "0x6bf924137e769c0a5c443dce6ec885552d31d579",
+        "baseToken": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7eb878107af0440f9e776f999ce053d277c8aca8000200000000000000000012",
+        "address": "0x7eb878107af0440f9e776f999ce053d277c8aca8",
+        "poolType": "Weighted",
+        "swapFee": "0.0056",
+        "totalShares": "34557.840677741304414213",
+        "tokens": [
+            {
+                "address": "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
+                "balance": "481898.5207",
+                "decimals": 4,
+                "weight": "0.7",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "8.889138419868061437",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x27054b13b1b798b345b591a4d22e6562d47ea75a",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x787546bf2c05e3e19e2b6bde57a203da7f682eff00020000000000000000007c",
+        "address": "0x787546bf2c05e3e19e2b6bde57a203da7f682eff",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "83306.796571080239346522",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "65548.119224",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf38c3e836be9cd35072055ff6a9ba570e0b70797",
+                "balance": "18143.732076",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xf38c3e836be9cd35072055ff6a9ba570e0b70797"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1635528110",
+        "unitSeconds": "583803612",
+        "principalToken": "0xf38c3e836be9cd35072055ff6a9ba570e0b70797",
+        "baseToken": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9f2b223da9f3911698c9b90ecdf3ffee37dd54a8000200000000000000000041",
+        "address": "0x9f2b223da9f3911698c9b90ecdf3ffee37dd54a8",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "7695.343192739579425441",
+        "tokens": [
+            {
+                "address": "0xa279dab6ec190ee4efce7da72896eb58ad533262",
+                "balance": "1074099.159166171432417143",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "14.074812905402795546",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa279dab6ec190ee4efce7da72896eb58ad533262",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x60b4601cdddc4467f31b1f770cb93c51dc7dc728000200000000000000000042",
+        "address": "0x60b4601cdddc4467f31b1f770cb93c51dc7dc728",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "41928.466454779808079682",
+        "tokens": [
+            {
+                "address": "0x89045d0af6a12782ec6f701ee6698beaf17d0ea2",
+                "balance": "33135592.537647216397362106",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "13.613422690508549537",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x89045d0af6a12782ec6f701ee6698beaf17d0ea2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x760afd4460089edbb77f71149f6fe1d7554c545000010000000000000000011d",
+        "address": "0x760afd4460089edbb77f71149f6fe1d7554c5450",
+        "poolType": "Weighted",
+        "swapFee": "0.05",
+        "totalShares": "57653.918176760758484041",
+        "tokens": [
+            {
+                "address": "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+                "balance": "32934.79174093",
+                "decimals": 8,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
+                "balance": "19635.142965702150427417",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x8f693ca8d21b157107184d29d398a8d082b38b76",
+                "balance": "137404.617369426588330208",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+                "balance": "20781.934823450524295939",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
+                "balance": "27262.782597915862141748",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "8997.277545",
+                "decimals": 6,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "3.127115580955120318",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+                "balance": "8197.135751884242910542",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x41e5560054824ea6b0732e656e3ad64e20e94e45",
+            "0x89ab32156e46f46d02ade3fecbe5fc4243b9aaed",
+            "0x8f693ca8d21b157107184d29d398a8d082b38b76",
+            "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+            "0x9992ec3cf6a55b00978cddf2b27bc6882d88d1ec",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x67b532d47a31ce1ed0800e6913dbf5f6e9c48a180002000000000000000000c5",
+        "address": "0x67b532d47a31ce1ed0800e6913dbf5f6e9c48a18",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "3198.406244340441283887",
+        "tokens": [
+            {
+                "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+                "balance": "6668.44802374522261435",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "5.480883250870280329",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6d39e85025fdc6fd7b1333454a2e18b873583f7c0002000000000000000001c5",
+        "address": "0x6d39e85025fdc6fd7b1333454a2e18b873583f7c",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "603905583690751.802808223273744684",
+        "tokens": [
+            {
+                "address": "0x72b734e6046304a78734937da869638e7e5b51d0",
+                "balance": "382817048620731.366629412924487529",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "11143.756626",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x72b734e6046304a78734937da869638e7e5b51d0",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc2a71921d945be82dc6371096300422c1cc422cf00020000000000000000019e",
+        "address": "0xc2a71921d945be82dc6371096300422c1cc422cf",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "928969040360.637919060562152632",
+        "tokens": [
+            {
+                "address": "0x1be686d5be49a44bdaa1104d89509ad6860ab779",
+                "balance": "593130138452.014745162888492312",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "8.944498414973649754",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1be686d5be49a44bdaa1104d89509ad6860ab779",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd000100000000000000000001",
+        "address": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "16.29287758066365815",
+        "tokens": [
+            {
+                "address": "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
+                "balance": "96.245502401850802606",
+                "decimals": 18,
+                "weight": "0.333333333333333333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.36267155",
+                "decimals": 8,
+                "weight": "0.333333333333333333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "4.940703350390775791",
+                "decimals": 18,
+                "weight": "0.333333333333333334",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1494ca1f11d487c2bbe4543e90080aeba4ba3c2b",
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x20facecaa68e9b7c92d2d0ec9136d864df805233000100000000000000000190",
+        "address": "0x20facecaa68e9b7c92d2d0ec9136d864df805233",
+        "poolType": "Weighted",
+        "swapFee": "0.0042",
+        "totalShares": "3015.501880811702481223",
+        "tokens": [
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "36.193915608620826603",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "389.995374817181505632",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba5bde662c17e2adff1075610382b9b691296350",
+                "balance": "11921.600142290949271148",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+                "balance": "227.70267862068176598",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+                "balance": "168.805990546514178072",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+                "balance": "1026.411889768634093659",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+                "balance": "428.736879927181793028",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb",
+                "balance": "145.056820340412797078",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xba5bde662c17e2adff1075610382b9b691296350",
+            "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+            "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+            "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+            "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+            "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5aa90c7362ea46b3cbfbd7f01ea5ca69c98fef1c000200000000000000000020",
+        "address": "0x5aa90c7362ea46b3cbfbd7f01ea5ca69c98fef1c",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "271.692613055162148044",
+        "tokens": [
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "2657.038864934618839395",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "7.084694156133366395",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x71628c66c502f988fbb9e17081f2bd14e361faf4000200000000000000000078",
+        "address": "0x71628c66c502f988fbb9e17081f2bd14e361faf4",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "38620.042819169376924234",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "12066.465082786331677192",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb1cc77e701de60fe246607565cf7edc9d9b6b963",
+                "balance": "26755.649644391793616256",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xb1cc77e701de60fe246607565cf7edc9d9b6b963"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1634346845",
+        "unitSeconds": "700248765",
+        "principalToken": "0xb1cc77e701de60fe246607565cf7edc9d9b6b963",
+        "baseToken": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4aa462d59361fc0115b3ab7e447627534a8642ae000100000000000000000158",
+        "address": "0x4aa462d59361fc0115b3ab7e447627534a8642ae",
+        "poolType": "Weighted",
+        "swapFee": "0.06",
+        "totalShares": "1112.842371913719897048",
+        "tokens": [
+            {
+                "address": "0x45804880de22913dafe09f4980848ece6ecbaf78",
+                "balance": "6.662605146051533683",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "25602.068249",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "4.409380692081415343",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x45804880de22913dafe09f4980848ece6ecbaf78",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x77952e11e1ba727ffcea95a0f38ed7da586eebc7000200000000000000000116",
+        "address": "0x77952e11e1ba727ffcea95a0f38ed7da586eebc7",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "83026.287935614672598686",
+        "tokens": [
+            {
+                "address": "0x13c99770694f07279607a6274f28a28c33086424",
+                "balance": "2247050.22491368379883443",
+                "decimals": 18,
+                "weight": "0.7",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "3.89308234268240261",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x13c99770694f07279607a6274f28a28c33086424",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x29d7a7e0d781c957696697b94d4bc18c651e358e000200000000000000000049",
+        "address": "0x29d7a7e0d781c957696697b94d4bc18c651e358e",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "586.915553045596299108",
+        "tokens": [
+            {
+                "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+                "balance": "15722.631823348132512773",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "5.674764192198060111",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x494b26d4aee801cb1fabf498ee24f0af20238743000200000000000000000083",
+        "address": "0x494b26d4aee801cb1fabf498ee24f0af20238743",
+        "poolType": "Weighted",
+        "swapFee": "0.001499999999999999",
+        "totalShares": "155082.308481711223343265",
+        "tokens": [
+            {
+                "address": "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
+                "balance": "6457092.409619567732913827",
+                "decimals": 18,
+                "weight": "0.7",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "2.60432556819343979",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x4730fb1463a6f1f44aeb45f6c5c422427f37f4d0",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9e030b67a8384cbba09d5927533aa98010c87d9100020000000000000000008f",
+        "address": "0x9e030b67a8384cbba09d5927533aa98010c87d91",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "176665.138572411247631417",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "12073.08907",
+                "decimals": 6,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf1294e805b992320a3515682c6ab0fe6251067e5",
+                "balance": "650312.28391",
+                "decimals": 6,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xf1294e805b992320a3515682c6ab0fe6251067e5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa5629408958264c2bce5217a0466924644e311ed0002000000000000000000f8",
+        "address": "0xa5629408958264c2bce5217a0466924644e311ed",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "15526.104556490147897754",
+        "tokens": [
+            {
+                "address": "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
+                "balance": "22011.620040219836310449",
+                "decimals": 18,
+                "weight": "0.9",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.712069684422405423",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xabe580e7ee158da464b51ee1a83ac0289622e6be",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x148ce9b50be946a96e94a4f5479b771bab9b1c59000100000000000000000054",
+        "address": "0x148ce9b50be946a96e94a4f5479b771bab9b1c59",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "324.482469572566127517",
+        "tokens": [
+            {
+                "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+                "balance": "16.078380394278439674",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "5067.146691548671451835",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "374.537076413690414797",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "1.670232345283613454",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6810e776880c02933d47db1b9fc05908e5386b96",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7173b184525fead2ffbde5fbe6fcb65ea8246ee70002000000000000000000c7",
+        "address": "0x7173b184525fead2ffbde5fbe6fcb65ea8246ee7",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "98003.450357987236366269",
+        "tokens": [
+            {
+                "address": "0x29cca1dba3f2db3c2708608d2676ff8044c14073",
+                "balance": "413663.983818",
+                "decimals": 6,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "5881.392933",
+                "decimals": 6,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x29cca1dba3f2db3c2708608d2676ff8044c14073",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xde148e6cc3f6047eed6e97238d341a2b8589e19e000200000000000000000017",
+        "address": "0xde148e6cc3f6047eed6e97238d341a2b8589e19e",
+        "poolType": "Weighted",
+        "swapFee": "0.0029",
+        "totalShares": "115.232962858028039249",
+        "tokens": [
+            {
+                "address": "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+                "balance": "6984.016474953669666076",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "2.39961276352081003",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0d8775f648430679a709e98d2b0cb6250d2887ef",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x23f91b4931d8eb25beae8585525ca433c3ad2cd700020000000000000000018e",
+        "address": "0x23f91b4931d8eb25beae8585525ca433c3ad2cd7",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "873.092460982420870666",
+        "tokens": [
+            {
+                "address": "0x2c66d4a60f9decddab32856e2e50dd50926438e2",
+                "balance": "199.5436",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "10000.0",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2c66d4a60f9decddab32856e2e50dd50926438e2",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe24281bc68c2a56e19b67b3787fd5e95937bd970000200000000000000000062",
+        "address": "0xe24281bc68c2a56e19b67b3787fd5e95937bd970",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "3.130319655403027339",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "1.456929176293345337",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd075e95423c5c4ba1e122cae0f4cdfa19b82881b",
+                "balance": "1.707263544776426108",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd075e95423c5c4ba1e122cae0f4cdfa19b82881b"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7c9cf12d783821d5c63d8e9427af5c44bad924450002000000000000000000b4",
+        "address": "0x7c9cf12d783821d5c63d8e9427af5c44bad92445",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "82966.321549226031910552",
+        "tokens": [
+            {
+                "address": "0x33dde19c163cdcce4e5a81f04a2af561b9ef58d7",
+                "balance": "425786.660007",
+                "decimals": 6,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "4069.983554",
+                "decimals": 6,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x33dde19c163cdcce4e5a81f04a2af561b9ef58d7",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9c08c7a7a89cfd671c79eacdc6f07c1996277ed5000200000000000000000025",
+        "address": "0x9c08c7a7a89cfd671c79eacdc6f07c1996277ed5",
+        "poolType": "Weighted",
+        "swapFee": "0.0007",
+        "totalShares": "2073.896351938041864782",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "3849.051475",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "281.64714934530949714",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0297e37f1873d2dab4487aa67cd56b58e2f27875000200000000000000000003",
+        "address": "0x0297e37f1873d2dab4487aa67cd56b58e2f27875",
+        "poolType": "Weighted",
+        "swapFee": "0.0004",
+        "totalShares": "0.595047885260633831",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.0812808",
+                "decimals": 8,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "1.09372379941545775",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xcf354603a9aebd2ff9f33e1b04246d8ea204ae950002000000000000000000eb",
+        "address": "0xcf354603a9aebd2ff9f33e1b04246d8ea204ae95",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "2.072756786878419281",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.08121545",
+                "decimals": 8,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b25b806a48b0d7cfa8399e3537479ddde7c931f",
+                "balance": "13.23995553",
+                "decimals": 8,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x6b25b806a48b0d7cfa8399e3537479ddde7c931f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf8a0623ab66f985effc1c69d05f1af4badb01b0000020000000000000000001d",
+        "address": "0xf8a0623ab66f985effc1c69d05f1af4badb01b00",
+        "poolType": "Weighted",
+        "swapFee": "0.0031",
+        "totalShares": "245.023183737577297415",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "555.243418867213520336",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.299186067545215944",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa660ba113f9aabaeb4bcd28a4a1705f4997d5432000200000000000000000022",
+        "address": "0xa660ba113f9aabaeb4bcd28a4a1705f4997d5432",
+        "poolType": "Weighted",
+        "swapFee": "0.0095",
+        "totalShares": "125236.556513275480738383",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "863.566598",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xff20817765cb7f73d4bde2e66e067e58d11095c2",
+                "balance": "184898.627510072825541729",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xff20817765cb7f73d4bde2e66e067e58d11095c2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xbb31b8eebb9c71001562ae56aa5751af313e6d8900020000000000000000002e",
+        "address": "0xbb31b8eebb9c71001562ae56aa5751af313e6d89",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "3400.487077172111983632",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.271929897216599511",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf65b5c5104c4fafd4b709d9d60a185eae063276c",
+                "balance": "15310.711914017596622993",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf65b5c5104c4fafd4b709d9d60a185eae063276c"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x415747ee98d482e6dd9b431fa76ad5553744f247000200000000000000000122",
+        "address": "0x415747ee98d482e6dd9b431fa76ad5553744f247",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "50971.40688952323081285",
+        "tokens": [
+            {
+                "address": "0x38c9728e474a73bccf82705e29de4ca41852b8c8",
+                "balance": "330457.036862390365616776",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "1969.201012161787831463",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x38c9728e474a73bccf82705e29de4ca41852b8c8",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0a0aaca26afe68a04745be1052ef04b534cc77e20002000000000000000001a8",
+        "address": "0x0a0aaca26afe68a04745be1052ef04b534cc77e2",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "335276988959498.149403076737494488",
+        "tokens": [
+            {
+                "address": "0x0c8b172d7d5910038f2fac6ad2709ab27ad88b88",
+                "balance": "30259475624127.359210669980901195",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "1.381594758401206398",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0c8b172d7d5910038f2fac6ad2709ab27ad88b88",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x14462305d211c12a736986f4e8216e28c5ea7ab4000200000000000000000068",
+        "address": "0x14462305d211c12a736986f4e8216e28c5ea7ab4",
+        "poolType": "Weighted",
+        "swapFee": "0.0035",
+        "totalShares": "6214.546086350892395711",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "1907.605083",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                "balance": "5259.686776156312066871",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0a54996ce9ceaa449cde73da6aa0368bfe3df6dc000200000000000000000102",
+        "address": "0x0a54996ce9ceaa449cde73da6aa0368bfe3df6dc",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "958.562849629842549438",
+        "tokens": [
+            {
+                "address": "0x7287b8d79e7f2ad2653635d96cc8bdb41284bed2",
+                "balance": "499.8329980830760755",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "61.0",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7287b8d79e7f2ad2653635d96cc8bdb41284bed2",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x2d6e3515c8b47192ca3913770fa741d3c4dac35400020000000000000000007b",
+        "address": "0x2d6e3515c8b47192ca3913770fa741d3c4dac354",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "18541.632681519250763991",
+        "tokens": [
+            {
+                "address": "0x5d67c1c829ab93867d865cf2008deb45df67044f",
+                "balance": "65412.167709",
+                "decimals": 6,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "1323.691607",
+                "decimals": 6,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5d67c1c829ab93867d865cf2008deb45df67044f",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb70c25d96ef260ea07f650037bf68f5d6583885e000200000000000000000096",
+        "address": "0xb70c25d96ef260ea07f650037bf68f5d6583885e",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "21325.319539300715540731",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "1276.481870912671858398",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf6d2699b035fc8fd5e023d4a6da216112ad8a985",
+                "balance": "89350.17486880864724505",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xf6d2699b035fc8fd5e023d4a6da216112ad8a985"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x89ea4363bd541d27d9811e4df1209daa73154472000200000000000000000034",
+        "address": "0x89ea4363bd541d27d9811e4df1209daa73154472",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "1048.517662753138964194",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.138072248446991366",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                "balance": "4121.647619939424911613",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc6a5032dc4bf638e15b4a66bc718ba7ba474ff73000200000000000000000004",
+        "address": "0xc6a5032dc4bf638e15b4a66bc718ba7ba474ff73",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "19.249031279382203913",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "887.488762071553967112",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.478419278660555502",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x240273a118a67bb878ca5fc3c3d645d60622f6f400020000000000000000017b",
+        "address": "0x240273a118a67bb878ca5fc3c3d645d60622f6f4",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.126372971546803544",
+        "tokens": [
+            {
+                "address": "0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf",
+                "balance": "1.762226453401905389",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000433248743788222",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xab846fb6c81370327e784ae7cbb6d6a6af6ff4bf",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3f725ed5791b72554e9bedf461eb76fc72db883400020000000000000000017a",
+        "address": "0x3f725ed5791b72554e9bedf461eb76fc72db8834",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "56873.715868639678073433",
+        "tokens": [
+            {
+                "address": "0x4daeb4a06f70f4b1a5c329115731fe4b89c0b227",
+                "balance": "883366.528294343646739632",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "920.383308",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x4daeb4a06f70f4b1a5c329115731fe4b89c0b227",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5e6989c0e2b6600ab585d56bf05479d5450a60c80002000000000000000000c1",
+        "address": "0x5e6989c0e2b6600ab585d56bf05479d5450a60c8",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "21.05447825089214078",
+        "tokens": [
+            {
+                "address": "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+                "balance": "58.30293805823582419",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.011378103703222749",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xb62132e35a6c13ee1ee0f84dc5d40bad8d815206",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb2634e2bfab9664f603626afc3d270be63c09ade000200000000000000000053",
+        "address": "0xb2634e2bfab9664f603626afc3d270be63c09ade",
+        "poolType": "Weighted",
+        "swapFee": "0.015",
+        "totalShares": "189.404887618316304056",
+        "tokens": [
+            {
+                "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
+                "balance": "580.402959388539683563",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.076156965812930525",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x16faf9f73748013155b7bc116a3008b57332d1e600020000000000000000001c",
+        "address": "0x16faf9f73748013155b7bc116a3008b57332d1e6",
+        "poolType": "Weighted",
+        "swapFee": "0.0011",
+        "totalShares": "11.695533197387630314",
+        "tokens": [
+            {
+                "address": "0xb4efd85c19999d84251304bda99e90b92300bd93",
+                "balance": "31.138244909263014722",
+                "decimals": 18,
+                "weight": "0.7",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.121185457755822838",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xb4efd85c19999d84251304bda99e90b92300bd93",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x56b2811bf75bb258d2234af4f43b479bb55c3b46000200000000000000000091",
+        "address": "0x56b2811bf75bb258d2234af4f43b479bb55c3b46",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "1324.089093547124986512",
+        "tokens": [
+            {
+                "address": "0x10010078a54396f62c96df8532dc2b4847d47ed3",
+                "balance": "6786.78932288421136466",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.091094451984536071",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x10010078a54396f62c96df8532dc2b4847d47ed3",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9e7fd25ad9d97f1e6716fa5bb04749a4621e892d000100000000000000000039",
+        "address": "0x9e7fd25ad9d97f1e6716fa5bb04749a4621e892d",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "7.500211493376452774",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.006880597248297883",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+                "balance": "93.783175182901089018",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.847145403177888364",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.080969852922421252",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "10.318927603320386066",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "1.017505531277656822",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                "balance": "28.671004453633964062",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.050606833304016008",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6b7c875b3bbb29ecc69807ac540dc7f05cbcbd10000200000000000000000173",
+        "address": "0x6b7c875b3bbb29ecc69807ac540dc7f05cbcbd10",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "4172713635.127553335116074672",
+        "tokens": [
+            {
+                "address": "0x7660bd4dd73d97a045872a3377f0c78f66005897",
+                "balance": "2615149991",
+                "decimals": 0,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.4",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7660bd4dd73d97a045872a3377f0c78f66005897",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x517390b2b806cb62f20ad340de6d98b2a8f17f2b0002000000000000000001ba",
+        "address": "0x517390b2b806cb62f20ad340de6d98b2a8f17f2b",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "86893.588032488708917124",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.075636200790469105",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe29797910d413281d2821d5d9a989262c8121cc2",
+                "balance": "1196537.445798729998353564",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xe29797910d413281d2821d5d9a989262c8121cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x80be0c303d8ad2a280878b50a39b1ee8e54dbd2200020000000000000000000f",
+        "address": "0x80be0c303d8ad2a280878b50a39b1ee8e54dbd22",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "3.649236786017312758",
+        "tokens": [
+            {
+                "address": "0x58b6a8a3302369daec383334672404ee733ab239",
+                "balance": "19.817739251960219871",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.175121255168168745",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x58b6a8a3302369daec383334672404ee733ab239",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xea8886a24b6e01fba88a9e98d794e8d1f29ed863000200000000000000000010",
+        "address": "0xea8886a24b6e01fba88a9e98d794e8d1f29ed863",
+        "poolType": "Weighted",
+        "swapFee": "0.002",
+        "totalShares": "156.23062473016278752",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.066420503457006049",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe41d2489571d322189246dafa5ebde1f4699f498",
+                "balance": "832.475236861738391896",
+                "decimals": 18,
+                "weight": "0.75",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xe41d2489571d322189246dafa5ebde1f4699f498"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5d563ca1e2daaae3402c36097b934630ab53702c000200000000000000000024",
+        "address": "0x5d563ca1e2daaae3402c36097b934630ab53702c",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "17.225068940355162734",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.15513561323045425",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe2f2a5c287993345a840db3b0845fbc70f5935a5",
+                "balance": "478.732010129335855619",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xe2f2a5c287993345a840db3b0845fbc70f5935a5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe54b3f5c444a801e61becdca93e74cdc1c4c1f90000200000000000000000077",
+        "address": "0xe54b3f5c444a801e61becdca93e74cdc1c4c1f90",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "8072.292564835522435059",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "442.422549345374429087",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa1cc9bbcd3731a9fd43e1f1416f9b6bf824f37d7",
+                "balance": "36958.887879142402285308",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xa1cc9bbcd3731a9fd43e1f1416f9b6bf824f37d7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x39cd55ff7e7d7c66d7d2736f1d5d4791cdab895b000100000000000000000071",
+        "address": "0x39cd55ff7e7d7c66d7d2736f1d5d4791cdab895b",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "15.328509775158519837",
+        "tokens": [
+            {
+                "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+                "balance": "78.501641269946091434",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+                "balance": "29.701937277427016776",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+                "balance": "0.973866726433230259",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+                "balance": "0.736572785805849887",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+                "balance": "5.064736371152290308",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+                "balance": "1.295943489744034642",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "0.619599291284841804",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.031024362569750872",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+            "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+            "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+            "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+            "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+            "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb6b9b165c4ac3f5233a0cf413126c72be28b468a00010000000000000000005a",
+        "address": "0xb6b9b165c4ac3f5233a0cf413126c72be28b468a",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "9.731024914717662392",
+        "tokens": [
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "7.106796557666902784",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+                "balance": "20.350684464093358773",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.458179995950018385",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.050480619372569735",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "5.342132219684034314",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "0.603341834907426686",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                "balance": "14.837495085729431304",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.03196748706922971",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3adc2c446026c57a876a2df4857d69092922f4090002000000000000000001e3",
+        "address": "0x3adc2c446026c57a876a2df4857d69092922f409",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "322318987122.519426751299829758",
+        "tokens": [
+            {
+                "address": "0x068b1ccc7f460b957306d2cddda3fe61c25b2f4e",
+                "balance": "200000000000.0",
+                "decimals": 18,
+                "weight": "0.820403785741969775",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "83.225208",
+                "decimals": 6,
+                "weight": "0.179611473472465991",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x068b1ccc7f460b957306d2cddda3fe61c25b2f4e",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6ae82385f76e3742f89cb46343b169f6ee49de1b000200000000000000000016",
+        "address": "0x6ae82385f76e3742f89cb46343b169f6ee49de1b",
+        "poolType": "Weighted",
+        "swapFee": "0.0051",
+        "totalShares": "7664.611857800272671831",
+        "tokens": [
+            {
+                "address": "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+                "balance": "69539.53",
+                "decimals": 2,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.036629391135052103",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x467bccd9d29f223bce8043b84e8c8b282827790f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8a92c3afabab59101b4e2426c82a7ddbb66b545000020000000000000000001f",
+        "address": "0x8a92c3afabab59101b4e2426c82a7ddbb66b5450",
+        "poolType": "Weighted",
+        "swapFee": "0.0079",
+        "totalShares": "2994.626429568217462794",
+        "tokens": [
+            {
+                "address": "0x95a4492f028aa1fd432ea71146b433e7b4446611",
+                "balance": "2918.253701583559336273",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "105.378047",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x95a4492f028aa1fd432ea71146b433e7b4446611",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x518f6cbcb1ba838f0557d95bf67b52e2ca55f03d00020000000000000000013b",
+        "address": "0x518f6cbcb1ba838f0557d95bf67b52e2ca55f03d",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "3754.489966666427541922",
+        "tokens": [
+            {
+                "address": "0x3810e0c32d47c81e02f8dc0feb439f1775596a8d",
+                "balance": "7000.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "504.155755",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x3810e0c32d47c81e02f8dc0feb439f1775596a8d",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x820298d6c264c2bb95152c44270d8729057ec467000200000000000000000171",
+        "address": "0x820298d6c264c2bb95152c44270d8729057ec467",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.08",
+        "totalShares": "32480604.540088452025327318",
+        "tokens": [
+            {
+                "address": "0xbc138bd20c98186cc0342c8e380953af0cb48ba8",
+                "balance": "22908854.5790870066224959",
+                "decimals": 18,
+                "weight": "0.684739072781479359",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.046049680302428541",
+                "decimals": 18,
+                "weight": "0.315276186328196927",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xbc138bd20c98186cc0342c8e380953af0cb48ba8",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8339e311265a025fd5792db800daa8eda4264e2c000200000000000000000029",
+        "address": "0x8339e311265a025fd5792db800daa8eda4264e2c",
+        "poolType": "Weighted",
+        "swapFee": "0.0006",
+        "totalShares": "603.828365622977055354",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.01290069408620267",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b",
+                "balance": "923.82520181362551953",
+                "decimals": 18,
+                "weight": "0.9",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x45910faff3cbf990fdb204682e93055506682d1700020000000000000000000d",
+        "address": "0x45910faff3cbf990fdb204682e93055506682d17",
+        "poolType": "Weighted",
+        "swapFee": "0.0025",
+        "totalShares": "1359.397265191533601432",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "39.332728",
+                "decimals": 6,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b",
+                "balance": "933.38413057444460635",
+                "decimals": 18,
+                "weight": "0.9",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xf1f955016ecbcd7321c7266bccfb96c68ea5e49b"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x38a01c45d86b61a70044fb2a76eac8e75b1ac78e00020000000000000000003a",
+        "address": "0x38a01c45d86b61a70044fb2a76eac8e75b1ac78e",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "4.307603856654849428",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "57.16437654967321866",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9e7fd25ad9d97f1e6716fa5bb04749a4621e892d",
+                "balance": "0.949130575490556172",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x9e7fd25ad9d97f1e6716fa5bb04749a4621e892d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xdb3e5cf969c05625db344dea9c8b12515e235df300010000000000000000006a",
+        "address": "0xdb3e5cf969c05625db344dea9c8b12515e235df3",
+        "poolType": "Weighted",
+        "swapFee": "0.02",
+        "totalShares": "4.663933918739813811",
+        "tokens": [
+            {
+                "address": "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e",
+                "balance": "1.323022835451454464",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+                "balance": "0.116336086512748935",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
+                "balance": "141.036217583192977284",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+                "balance": "3.312451939741139973",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+                "balance": "0.357074814445131181",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+                "balance": "1.716769196951307697",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.007599340300623796",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+                "balance": "0.058695222530853431",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e",
+            "0x2ba592f78db6436527729929aaf6c908497cb200",
+            "0x584bc13c7d411c00c01a62e8019472de68768430",
+            "0x6dea81c8171d0ba574754ef6f8b412f2ed88c54d",
+            "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+            "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xdbdb4d16eda451d0503b854cf79d55697f90c8df"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x344e8f99a55da2ba6b4b5158df2143374e400df2000100000000000000000079",
+        "address": "0x344e8f99a55da2ba6b4b5158df2143374e400df2",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "6.079362686920985605",
+        "tokens": [
+            {
+                "address": "0x0ec9f76202a7061eb9b3a7d6b59d36215a7e37da",
+                "balance": "1.961803947576044712",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+                "balance": "6.853170750200303255",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+                "balance": "2.926631175327682247",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+                "balance": "14.423174012293712481",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+                "balance": "0.123976658398697516",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+                "balance": "0.657168778551755824",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+                "balance": "0.264257518982686247",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.011985267203473692",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0ec9f76202a7061eb9b3a7d6b59d36215a7e37da",
+            "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+            "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+            "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+            "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+            "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+            "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7320d680ca9bce8048a286f00a79a2c9f8dcd7b3000200000000000000000085",
+        "address": "0x7320d680ca9bce8048a286f00a79a2c9f8dcd7b3",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.069079493456630054",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.00285938",
+                "decimals": 8,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3b32f63c1e0fb810f0a06814ead1d4431b237560",
+                "balance": "0.41769695",
+                "decimals": 8,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x3b32f63c1e0fb810f0a06814ead1d4431b237560"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x09804caea2400035b18e2173fdd10ec8b670ca09000100000000000000000038",
+        "address": "0x09804caea2400035b18e2173fdd10ec8b670ca09",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "1.789761506144239909",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "4.562300116085354789",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.001256657629424214",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "2.5330895310392978",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+                "balance": "1.949409240792221736",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.154339756888995831",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.017270757086778536",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                "balance": "6.797743055514518937",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.012346641812866986",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8a8fcd351ed553fc75aecbc566a32f94471f302e00010000000000000000012a",
+        "address": "0x8a8fcd351ed553fc75aecbc566a32f94471f302e",
+        "poolType": "Weighted",
+        "swapFee": "0.000569",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.000000000016569443",
+                "decimals": 18,
+                "weight": "0.333333333333333333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+                "balance": "0.000000000000004823",
+                "decimals": 18,
+                "weight": "0.333333333333333333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+                "balance": "0.000000000000466028",
+                "decimals": 18,
+                "weight": "0.333333333333333334",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xae78736cd615f374d3085123a210448e74fc6393",
+            "0xd33526068d116ce69f19a9ee46f0bd304f21a51f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8f4063446f5011bc1c9f79a819efe87776f23704000000000000000000000197",
+        "address": "0x8f4063446f5011bc1c9f79a819efe87776f23704",
+        "poolType": "ERC4626Linear",
+        "swapFee": "0.0002",
+        "totalShares": "152.150769762942109065",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "152.150769762942109065",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x8f4063446f5011bc1c9f79a819efe87776f23704",
+                "balance": "5192296858534675.47776073338711103",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba63738c2e476b1a0cfb6b41a7b85d304d032454",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.0"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x8f4063446f5011bc1c9f79a819efe87776f23704",
+            "0xba63738c2e476b1a0cfb6b41a7b85d304d032454"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 2,
+        "mainIndex": 0,
+        "lowerTarget": "0.0",
+        "upperTarget": "5000000.0"
+    },
+    {
+        "id": "0x5d66fff62c17d841935b60df5f07f6cf79bd0f4700020000000000000000014c",
+        "address": "0x5d66fff62c17d841935b60df5f07f6cf79bd0f47",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8",
+                "balance": "0.000000000036630802",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000006875",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6f80310ca7f2c654691d1383149fa1a57d8ab1f8",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6cd0c0e378fe120cf733ac1431bd1d308c5b6df0000200000000000000000144",
+        "address": "0x6cd0c0e378fe120cf733ac1431bd1d308c5b6df0",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "1.911541990694119572",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.021455748643305787",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf66cd2f8755a21d3c8683a10269f795c0532dd58",
+                "balance": "42.812441185584546828",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf66cd2f8755a21d3c8683a10269f795c0532dd58"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb0401ab1108bd26c85a07243dfdf09f4821d76a200020000000000000000007f",
+        "address": "0xb0401ab1108bd26c85a07243dfdf09f4821d76a2",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "16.373000015320498017",
+        "tokens": [
+            {
+                "address": "0x1e83916ea2ef2d7a6064775662e163b2d4c330a7",
+                "balance": "3317.690615130347023135",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.020245008266942111",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1e83916ea2ef2d7a6064775662e163b2d4c330a7",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xfa1575c57d887e93f37a3c267a548ede008458b300010000000000000000008c",
+        "address": "0xfa1575c57d887e93f37a3c267a548ede008458b3",
+        "poolType": "Weighted",
+        "swapFee": "0.0055",
+        "totalShares": "0.074087116336139811",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.00118005",
+                "decimals": 8,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "25.07646",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.016260684275612737",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x117fbaa48a188ed3d1605f2b49895fec28d6b0380002000000000000000001b3",
+        "address": "0x117fbaa48a188ed3d1605f2b49895fec28d6b038",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2930e74d4634ae54519ae0ccd69ce728531c252e",
+                "balance": "0.000457338221986958",
+                "decimals": 18,
+                "weight": "0.99",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000014",
+                "decimals": 18,
+                "weight": "0.01",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2930e74d4634ae54519ae0ccd69ce728531c252e",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x503717b3dc137e230afc7c772520d7974474fb70000200000000000000000081",
+        "address": "0x503717b3dc137e230afc7c772520d7974474fb70",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "118.079208078824273186",
+        "tokens": [
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "50.275944",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf1290473e210b2108a85237fbcd7b6eb42cc654f",
+                "balance": "69.434821322208680979",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "0xf1290473e210b2108a85237fbcd7b6eb42cc654f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe6bcc79f328eec93d4ec8f7ed35534d9ab549faa0000000000000000000000e8",
+        "address": "0xe6bcc79f328eec93d4ec8f7ed35534d9ab549faa",
+        "poolType": "AaveLinear",
+        "swapFee": "0.000005",
+        "totalShares": "100",
+        "tokens": [
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "100.0",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe6bcc79f328eec93d4ec8f7ed35534d9ab549faa",
+                "balance": "5192296858534727.628530496329220095",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf8fd466f12e236f4c96f7cce6c79eadb819abf58",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1.086299440697768775"
+            }
+        ],
+        "tokensList": [
+            "0xdac17f958d2ee523a2206206994597c13d831ec7",
+            "0xe6bcc79f328eec93d4ec8f7ed35534d9ab549faa",
+            "0xf8fd466f12e236f4c96f7cce6c79eadb819abf58"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 2,
+        "mainIndex": 0,
+        "lowerTarget": "0.0",
+        "upperTarget": "1000000.0"
+    },
+    {
+        "id": "0xa3823e50f20982656557a4a6a9c06ba5467ae9080000000000000000000000e6",
+        "address": "0xa3823e50f20982656557a4a6a9c06ba5467ae908",
+        "poolType": "AaveLinear",
+        "swapFee": "0.000005",
+        "totalShares": "100",
+        "tokens": [
+            {
+                "address": "0x02d60b84491589974263d922d9cc7a3152618ef6",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.071025392251319738"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "100.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa3823e50f20982656557a4a6a9c06ba5467ae908",
+                "balance": "5192296858534727.628530496329220095",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x02d60b84491589974263d922d9cc7a3152618ef6",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xa3823e50f20982656557a4a6a9c06ba5467ae908"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 1,
+        "lowerTarget": "0.0",
+        "upperTarget": "1000000.0"
+    },
+    {
+        "id": "0x652d486b80c461c397b0d95612a404da936f3db30000000000000000000000e7",
+        "address": "0x652d486b80c461c397b0d95612a404da936f3db3",
+        "poolType": "AaveLinear",
+        "swapFee": "0.000005",
+        "totalShares": "100",
+        "tokens": [
+            {
+                "address": "0x652d486b80c461c397b0d95612a404da936f3db3",
+                "balance": "5192296858534727.628530496329220095",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "100.0",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": null,
+                "priceRate": "1.074438118266225033"
+            }
+        ],
+        "tokensList": [
+            "0x652d486b80c461c397b0d95612a404da936f3db3",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xd093fa4fb80d09bb30817fdcd442d4d02ed3e5de"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 2,
+        "mainIndex": 1,
+        "lowerTarget": "0.0",
+        "upperTarget": "2100000.0"
+    },
+    {
+        "id": "0x3febe770201cf4d351d33708170b9202ba1c6af7000200000000000000000045",
+        "address": "0x3febe770201cf4d351d33708170b9202ba1c6af7",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "22056.955885932269065219",
+        "tokens": [
+            {
+                "address": "0x965d79f1a1016b574a62986e13ca8ab04dfdd15c",
+                "balance": "59477.478887928900979758",
+                "decimals": 18,
+                "weight": "0.9",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.003090674169771995",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x965d79f1a1016b574a62986e13ca8ab04dfdd15c",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x77ffd0a758b0a3960c208130b37f1130c2b9192a0002000000000000000000f5",
+        "address": "0x77ffd0a758b0a3960c208130b37f1130c2b9192a",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x41c37a4683d6a05adb31c39d71348a8403b13ca9",
+                "balance": "0.00000000000050486",
+                "decimals": 18,
+                "weight": "0.99",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.01",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x41c37a4683d6a05adb31c39d71348a8403b13ca9",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x647c1fd457b95b75d0972ff08fe01d7d7bda05df000200000000000000000002",
+        "address": "0x647c1fd457b95b75d0972ff08fe01d7d7bda05df",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "1.452812721321107546",
+        "tokens": [
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "2.764128129867829704",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.003476576254589853",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xed5d8fa2f341b1f6f264db560d9b8215e8beffaa000200000000000000000121",
+        "address": "0xed5d8fa2f341b1f6f264db560d9b8215e8beffaa",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "2.963553124739911606",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.004614433506862328",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xedb171c18ce90b633db442f2a6f72874093b49ef",
+                "balance": "6.27402620397618553",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xedb171c18ce90b633db442f2a6f72874093b49ef"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4fa6086ed10c971d255aa1b09a6beb1c7be5ca37000200000000000000000051",
+        "address": "0x4fa6086ed10c971d255aa1b09a6beb1c7be5ca37",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "361.447185446881857521",
+        "tokens": [
+            {
+                "address": "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
+                "balance": "2781.463882977631743327",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.003229489010566631",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x50de6856358cc35f3a9a57eaaa34bd4cb707d2cd",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x14bf727f67aa294ec36347bd95aba1a2c136fe7a00020000000000000000002c",
+        "address": "0x14bf727f67aa294ec36347bd95aba1a2c136fe7a",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "0.003012345700467398",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.007068872965949703",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "20.367218",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x170bc09ff5c966b39c7aa09d6b0351a8c8236a2d00010000000000000000014e",
+        "address": "0x170bc09ff5c966b39c7aa09d6b0351a8c8236a2d",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x8987a07ba83607a66c7351266e771fb865c9ca6c",
+                "balance": "0.000000000000273472",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbba8120b355bc70e771f28e151a141a126843cdf",
+                "balance": "0.000000000000175695",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000248",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf2ef3551c1945a7218fc4ec0a75c9ecfdf012a4f",
+                "balance": "0.000000000336593625",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8987a07ba83607a66c7351266e771fb865c9ca6c",
+            "0xbba8120b355bc70e771f28e151a141a126843cdf",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf2ef3551c1945a7218fc4ec0a75c9ecfdf012a4f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x03cd191f589d12b0582a99808cf19851e468e6b500020000000000000000002b",
+        "address": "0x03cd191f589d12b0582a99808cf19851e468e6b5",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.110767585394389049",
+        "tokens": [
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.004759778872322919",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.646553624519376179",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xdedb0a5abc452164fd241da019741026f6efdc7400020000000000000000019f",
+        "address": "0xdedb0a5abc452164fd241da019741026f6efdc74",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.657445724764943506",
+        "tokens": [
+            {
+                "address": "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
+                "balance": "10.805872025292978794",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.01",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x429881672b9ae42b8eba0e26cd9c73711b891ca5",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xba07d63875d0c2319d43cbb8a897f89bdafd7e8700020000000000000000011f",
+        "address": "0xba07d63875d0c2319d43cbb8a897f89bdafd7e87",
+        "poolType": "Weighted",
+        "swapFee": "0.0019",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x038a68ff68c393373ec894015816e33ad41bd564",
+                "balance": "0.000000000004225624",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000161",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x038a68ff68c393373ec894015816e33ad41bd564",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xaaac5297f76ed0158b2a39639d71647b7f2eb6be0002000000000000000000c3",
+        "address": "0xaaac5297f76ed0158b2a39639d71647b7f2eb6be",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "186.464417386046065976",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "3.5",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe59064a8185ed1fca1d17999621efedfab4425c9",
+                "balance": "97.628697327158605",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xe59064a8185ed1fca1d17999621efedfab4425c9"
+        ],
+        "totalWeight": "1.000015259720392182",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xad302e620fedb60078b33514757335545ba05c6d00020000000000000000004e",
+        "address": "0xad302e620fedb60078b33514757335545ba05c6d",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "0.475353342981078633",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.001163290433804474",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfca59cd816ab1ead66534d82bc21e7515ce441cf",
+                "balance": "0.899571231889504945",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xfca59cd816ab1ead66534d82bc21e7515ce441cf"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xcfebb7646a1996e54c89e5b0af5fa8440bc0e9f1000200000000000000000148",
+        "address": "0xcfebb7646a1996e54c89e5b0af5fa8440bc0e9f1",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "65671885.703031617390805986",
+        "tokens": [
+            {
+                "address": "0x3f3a2f9a610a0fde3dd7557be616efa3a95f06ef",
+                "balance": "73393405.91617355295",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "6.0",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x3f3a2f9a610a0fde3dd7557be616efa3a95f06ef",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259720392182",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x85be1e46283f5f438d1f864c2d925506571d544f0002000000000000000001aa",
+        "address": "0x85be1e46283f5f438d1f864c2d925506571d544f",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "27.332671543159902288",
+        "tokens": [
+            {
+                "address": "0x1e5193ccc53f25638aa22a940af899b692e10b09",
+                "balance": "90.0",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.007265916393522031",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1e5193ccc53f25638aa22a940af899b692e10b09",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6602315d19278278578830933aeaac0d684c9c3f00020000000000000000004f",
+        "address": "0x6602315d19278278578830933aeaac0d684c9c3f",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "2.632956264048640094",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000883108467816738",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xcc4304a31d09258b0029ea7fe63d032f52e44efe",
+                "balance": "8.180343500002793142",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xcc4304a31d09258b0029ea7fe63d032f52e44efe"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0d968094e386f9fbfb3797655ab8e4672c2cb73700020000000000000000014f",
+        "address": "0x0d968094e386f9fbfb3797655ab8e4672c2cb737",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x8987a07ba83607a66c7351266e771fb865c9ca6c",
+                "balance": "0.000000000010494366",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000023881",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8987a07ba83607a66c7351266e771fb865c9ca6c",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4dd7517de8065a688dd0e398ed031b6e469f9f0f000200000000000000000050",
+        "address": "0x4dd7517de8065a688dd0e398ed031b6e469f9f0f",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "6.119090345491451041",
+        "tokens": [
+            {
+                "address": "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
+                "balance": "25.013290585773993232",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000686045264154421",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xb705268213d593b8fd88d3fdeff93aff5cbdcfae",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3bb9d50a0743103f896d823b332ee15e231848d100020000000000000000015e",
+        "address": "0x3bb9d50a0743103f896d823b332ee15e231848d1",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "27.667749656377297754",
+        "tokens": [
+            {
+                "address": "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050",
+                "balance": "130.582372113846156102",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.001742532931948476",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb1c9557d8f0844451f85548334a5eef32a6e66300002000000000000000001e2",
+        "address": "0xb1c9557d8f0844451f85548334a5eef32a6e6630",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.000000000005527079",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfcfc434ee5bff924222e084a8876eee74ea7cfba",
+                "balance": "0.00000000000004532",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xfcfc434ee5bff924222e084a8876eee74ea7cfba"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3a271a9838b36ea8c42eaf230f969c6b40e4ac0400020000000000000000004d",
+        "address": "0x3a271a9838b36ea8c42eaf230f969c6b40e4ac04",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "0.135374235419386612",
+        "tokens": [
+            {
+                "address": "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+                "balance": "0.202000000001341454",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000853344960005667",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1776e1f26f98b1a5df9cd347953a26dd3cb46671",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc5daf328ab785c20c9100f6d347dd712f1a1c36e000200000000000000000172",
+        "address": "0xc5daf328ab785c20c9100f6d347dd712f1a1c36e",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.92436377316675033",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000066012823330326",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd5d86fc8d5c0ea1ac1ac5dfab6e529c9967a45e9",
+                "balance": "4.228934479843914941",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd5d86fc8d5c0ea1ac1ac5dfab6e529c9967a45e9"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x32f0dc9e2d890bac95106a65eb82db70bc58badb0002000000000000000000f4",
+        "address": "0x32f0dc9e2d890bac95106a65eb82db70bc58badb",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.017941075442004734",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "1.301524",
+                "decimals": 6,
+                "weight": "0.950011444266422523",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000052315899388041",
+                "decimals": 18,
+                "weight": "0.050003814755474175",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1874c311eb0833f31bf2cbc8c7b8cc21fa37be1e00020000000000000000016e",
+        "address": "0x1874c311eb0833f31bf2cbc8c7b8cc21fa37be1e",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "1.746997424153761572",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.763",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+                "balance": "1.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x85dca8667d020e694fdff06e7ee85e0c5c7c61a4000200000000000000000076",
+        "address": "0x85dca8667d020e694fdff06e7ee85e0c5c7c61a4",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "0.5",
+        "tokens": [
+            {
+                "address": "0x46a6c6aa64c148386af77c76a4666da961f8c65c",
+                "balance": "0.253276560487448026",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.261601148766888148",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x46a6c6aa64c148386af77c76a4666da961f8c65c",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1702000550",
+        "unitSeconds": "700248765",
+        "principalToken": "0x46a6c6aa64c148386af77c76a4666da961f8c65c",
+        "baseToken": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x632045a9cfa9d232d0dd46702033c850d0e06f0f0002000000000000000001be",
+        "address": "0x632045a9cfa9d232d0dd46702033c850d0e06f0f",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x809d62f1c6e35720fd88df1c9fa7dec82b6ada52",
+                "balance": "0.000001135329767555",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000001",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x809d62f1c6e35720fd88df1c9fa7dec82b6ada52",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0a9e96988e21c9a03b8dc011826a00259e02c46e000200000000000000000055",
+        "address": "0x0a9e96988e21c9a03b8dc011826a00259e02c46e",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "6.413998386846188339",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.043822294164481996",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe7f4294033d0fde6eecb94bef7da22fde68a61ec",
+                "balance": "235.0",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xe7f4294033d0fde6eecb94bef7da22fde68a61ec"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e000200000000000000000044",
+        "address": "0x614b5038611729ed49e0ded154d8a5d3af9d1d9e",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000033749923191245",
+        "tokens": [
+            {
+                "address": "0x45804880de22913dafe09f4980848ece6ecbaf78",
+                "balance": "0.000019455546751412",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000014638045899899",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x45804880de22913dafe09f4980848ece6ecbaf78",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf8cba1c22b6515982bf43e71b7e8b546a3323ea8000100000000000000000138",
+        "address": "0xf8cba1c22b6515982bf43e71b7e8b546a3323ea8",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.00000001",
+                "decimals": 8,
+                "weight": "0.3333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000059544",
+                "decimals": 18,
+                "weight": "0.3334",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdac17f958d2ee523a2206206994597c13d831ec7",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.3333",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x15432ba000e58e3c0ae52a5dec0579215ebc75d0000200000000000000000075",
+        "address": "0x15432ba000e58e3c0ae52a5dec0579215ebc75d0",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.21833742890305843",
+        "tokens": [
+            {
+                "address": "0x0404fd4f0c3b474e8525558ca3d3bc33cec7545a",
+                "balance": "1.0",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.011917808215000001",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0404fd4f0c3b474e8525558ca3d3bc33cec7545a",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0fa982bde66629772f0d9137429679904051de90000200000000000000000127",
+        "address": "0x0fa982bde66629772f0d9137429679904051de90",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x67b0928f8025d8548a4475a80c5444aa8087fdbe",
+                "balance": "0.01",
+                "decimals": 2,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x67b0928f8025d8548a4475a80c5444aa8087fdbe",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xdd421db33976789e965eeb5ce6238d65f5f000d20002000000000000000001d0",
+        "address": "0xdd421db33976789e965eeb5ce6238d65f5f000d2",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x333a4823466879eef910a04d473505da62142069",
+                "balance": "0.000000000000587336",
+                "decimals": 18,
+                "weight": "0.95",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000023479",
+                "decimals": 18,
+                "weight": "0.05",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x333a4823466879eef910a04d473505da62142069",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe0947a0d847f9662a6a22ca2eff9d7e6352a123e000100000000000000000073",
+        "address": "0xe0947a0d847f9662a6a22ca2eff9d7e6352a123e",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.00000001",
+                "decimals": 8,
+                "weight": "0.33",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x677ddbd918637e5f2c79e164d402454de7da8619",
+                "balance": "0.000000000185143579",
+                "decimals": 18,
+                "weight": "0.34",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000051158",
+                "decimals": 18,
+                "weight": "0.33",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x677ddbd918637e5f2c79e164d402454de7da8619",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3a19030ed746bd1c3f2b0f996ff9479af04c5f0a000100000000000000000005",
+        "address": "0x3a19030ed746bd1c3f2b0f996ff9479af04c5f0a",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.00000001",
+                "decimals": 8,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x35a18000230da775cac24873d00ff85bccded550",
+                "balance": "0.00000001",
+                "decimals": 8,
+                "weight": "0.01",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.49",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x35a18000230da775cac24873d00ff85bccded550",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x32fc95287b14eaef3afa92cccc48c285ee3a280a000200000000000000000006",
+        "address": "0x32fc95287b14eaef3afa92cccc48c285ee3a280a",
+        "poolType": "Weighted",
+        "swapFee": "0.009",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.00000001",
+                "decimals": 8,
+                "weight": "0.99",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0",
+                "balance": "0.0000000002349364",
+                "decimals": 18,
+                "weight": "0.01",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x261b45d85ccfeabb11f022eba346ee8d1cd488c0"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4080f182f6c654b87eaa3366139378c4b9a4626f0001000000000000000001d8",
+        "address": "0x4080f182f6c654b87eaa3366139378c4b9a4626f",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.00000001",
+                "decimals": 8,
+                "weight": "0.3333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+                "balance": "0.000000000044848512",
+                "decimals": 18,
+                "weight": "0.3334",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.000000000001524456",
+                "decimals": 18,
+                "weight": "0.3333",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x66d25e31cf63992db9d7c690b61762096f119288000200000000000000000129",
+        "address": "0x66d25e31cf63992db9d7c690b61762096f119288",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.070008392462043184",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa60d4a5c42cd6d4cc7987cb154e874d84096cb4a",
+                "balance": "0.0001",
+                "decimals": 4,
+                "weight": "0.930006866559853514",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xa60d4a5c42cd6d4cc7987cb154e874d84096cb4a"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf0d0fcbd9a4a9ac147acfd7450ba7d9e4c35dd90000200000000000000000143",
+        "address": "0xf0d0fcbd9a4a9ac147acfd7450ba7d9e4c35dd90",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x3250e701413896cf32a5bed36a148707d817a22e",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x3250e701413896cf32a5bed36a148707d817a22e",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf7cd489c2b7e199e2d3e8a982eb6fd51d71c1ce4000200000000000000000046",
+        "address": "0xf7cd489c2b7e199e2d3e8a982eb6fd51d71c1ce4",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x123151402076fc819b7564510989e475c9cd93ca",
+                "balance": "0.00000001",
+                "decimals": 8,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000104223",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x123151402076fc819b7564510989e475c9cd93ca",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa1039beb7a9aae096b41c4a8ad91efc8624d027900020000000000000000013e",
+        "address": "0xa1039beb7a9aae096b41c4a8ad91efc8624d0279",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x086ac08e018f7d3f0c2d0a8c362aa5fffca05d8e",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.860013733119707027",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.14000152590218967",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x086ac08e018f7d3f0c2d0a8c362aa5fffca05d8e",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc23cd64318f917420bb0592bb18ea50437fa823e00020000000000000000012f",
+        "address": "0xc23cd64318f917420bb0592bb18ea50437fa823e",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x727d053bd5fd52da64c3dd4f979b26f6e2b3dd47",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.630014496070801862",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.370000762951094835",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x727d053bd5fd52da64c3dd4f979b26f6e2b3dd47",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x604a625b1db031e8cde1d49d30d425e0b6cf734f0002000000000000000000d1",
+        "address": "0x604a625b1db031e8cde1d49d30d425e0b6cf734f",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbb3c2a170fbb8988cdb41c04344f9863b0f71c20",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xbb3c2a170fbb8988cdb41c04344f9863b0f71c20"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4eebc19e5f29dec3dea07f66b9e707afc8f28c060002000000000000000000b3",
+        "address": "0x4eebc19e5f29dec3dea07f66b9e707afc8f28c06",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x949d48eca67b17269629c7194f4b727d4ef9e5d6",
+                "balance": "0.000000000033983117",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x949d48eca67b17269629c7194f4b727d4ef9e5d6",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf461f2240b66d55dcf9059e26c022160c06863bf000100000000000000000007",
+        "address": "0xf461f2240b66d55dcf9059e26c022160c06863bf",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
+                "balance": "0.000000000001428563",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.000000000000000084",
+                "decimals": 18,
+                "weight": "0.07",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "0.000000000000153848",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x61d5dc44849c9c87b0856a2a311536205c96c7fd",
+                "balance": "0.00000000000000062",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.000000000011451302",
+                "decimals": 18,
+                "weight": "0.15",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.13",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.000000000000205095",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000003853",
+                "decimals": 18,
+                "weight": "0.15",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x03ab458634910aad20ef5f1c8ee96f1d6ac54919",
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x61d5dc44849c9c87b0856a2a311536205c96c7fd",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1d95129c18a8c91c464111fdf7d0eb241b37a98500020000000000000000015a",
+        "address": "0x1d95129c18a8c91c464111fdf7d0eb241b37a985",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.018",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.170000762951094835",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xcd747366bf5684f133fc019c61750e00624d8e87",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.830014496070801862",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xcd747366bf5684f133fc019c61750e00624d8e87"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x04953368a77af5b65512ee3536efe152b96aa453000200000000000000000100",
+        "address": "0x04953368a77af5b65512ee3536efe152b96aa453",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.100007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfc248cef4c8763838743d3bd599a27e1bd6397f4",
+                "balance": "0.000000000014626197",
+                "decimals": 18,
+                "weight": "0.900007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xfc248cef4c8763838743d3bd599a27e1bd6397f4"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6d68d7b0ca469bd1171f81a895e649d86d523c200002000000000000000000cc",
+        "address": "0x6d68d7b0ca469bd1171f81a895e649d86d523c20",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xddd6a0ecc3c6f6c102e5ea3d8af7b801d1a77ac8",
+                "balance": "0.00000000002313461",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xddd6a0ecc3c6f6c102e5ea3d8af7b801d1a77ac8"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6836bfa9b9d000036d41dbd44b40688c45055037000200000000000000000119",
+        "address": "0x6836bfa9b9d000036d41dbd44b40688c45055037",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
+                "balance": "0.000000000326117107",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.4",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b0b3a982b4634ac68dd83a4dbf02311ce324181",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc97dee022137a8c5f65b5138cc690fbe87806ed5000200000000000000000107",
+        "address": "0xc97dee022137a8c5f65b5138cc690fbe87806ed5",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.100007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf4f618eff5ef36cde2fca4fbd86554c62fb1382b",
+                "balance": "0.000000000019632506",
+                "decimals": 18,
+                "weight": "0.900007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xf4f618eff5ef36cde2fca4fbd86554c62fb1382b"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd153e1de63b478213b7b62bf47dcc4099608b1ae0002000000000000000000d8",
+        "address": "0xd153e1de63b478213b7b62bf47dcc4099608b1ae",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2a2550e0a75acec6d811ae3930732f7f3ad67588",
+                "balance": "0.000000000025439218",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2a2550e0a75acec6d811ae3930732f7f3ad67588",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb61bef0cf17b25542c061ed861f270d5ac88a6b70002000000000000000000d5",
+        "address": "0xb61bef0cf17b25542c061ed861f270d5ac88a6b7",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x3ea8ea4237344c9931214796d9417af1a1180770",
+                "balance": "0.000000000008045166",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x3ea8ea4237344c9931214796d9417af1a1180770",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf1b3256505159f6004da0b16e985ee46e6ffeea80002000000000000000000fa",
+        "address": "0xf1b3256505159f6004da0b16e985ee46e6ffeea8",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.100007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfc248cef4c8763838743d3bd599a27e1bd6397f4",
+                "balance": "0.000000000004668643",
+                "decimals": 18,
+                "weight": "0.900007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xfc248cef4c8763838743d3bd599a27e1bd6397f4"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe00609d1ff9ec2c5415f5b3d3f7acc7e21c3b1050002000000000000000001af",
+        "address": "0xe00609d1ff9ec2c5415f5b3d3f7acc7e21c3b105",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x6ad58cb51605ce245848750135ff8e8ef763692d",
+                "balance": "0.000000329721834852",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6ad58cb51605ce245848750135ff8e8ef763692d",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xfa22ec1c02f121083bf04fbbcaad019f490d7a3000020000000000000000002a",
+        "address": "0xfa22ec1c02f121083bf04fbbcaad019f490d7a30",
+        "poolType": "Weighted",
+        "swapFee": "0.0063",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+                "balance": "0.000000000000399306",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xbc396689893d065f41bc2c6ecbee5e0085233447"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc14bc4e007c249bd2ab8c0c8fe5465b61ca9f1f40002000000000000000000db",
+        "address": "0xc14bc4e007c249bd2ab8c0c8fe5465b61ca9f1f4",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.060013733119707027",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfc248cef4c8763838743d3bd599a27e1bd6397f4",
+                "balance": "0.000000000000476721",
+                "decimals": 18,
+                "weight": "0.94000152590218967",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xfc248cef4c8763838743d3bd599a27e1bd6397f4"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x35c5f3153fc34edda1001209ed5e19ed78ed67b80002000000000000000001a6",
+        "address": "0x35c5f3153fc34edda1001209ed5e19ed78ed67b8",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfa2d450694fa0fd3b2c41ae89d9404de30a88a1b",
+                "balance": "0.000000000333001609",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xfa2d450694fa0fd3b2c41ae89d9404de30a88a1b"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x43bac7ef4f0948f83869208492df87bd05d1bf9d000200000000000000000149",
+        "address": "0x43bac7ef4f0948f83869208492df87bd05d1bf9d",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.490012970168612192",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe4b5936dce1820f84509c89cce0f28c87988bad8",
+                "balance": "0.000000000032392544",
+                "decimals": 18,
+                "weight": "0.510002288853284505",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xe4b5936dce1820f84509c89cce0f28c87988bad8"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x38ff18c8322b675aefc74a5cdd7c8c0c461b97df0002000000000000000000f6",
+        "address": "0x38ff18c8322b675aefc74a5cdd7c8c0c461b97df",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfc248cef4c8763838743d3bd599a27e1bd6397f4",
+                "balance": "0.000000000004259401",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xfc248cef4c8763838743d3bd599a27e1bd6397f4"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xbccd9d4b953ada653b7c464665d7263e5e078a980002000000000000000000ef",
+        "address": "0xbccd9d4b953ada653b7c464665d7263e5e078a98",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+                "balance": "0.000000000003932943",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xefdec913b82e55287fb83df3c058891b724dba28000200000000000000000186",
+        "address": "0xefdec913b82e55287fb83df3c058891b724dba28",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x88aa4a6c5050b9a1b2aa7e34d0582025ca6ab745",
+                "balance": "0.000000000004312145",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x88aa4a6c5050b9a1b2aa7e34d0582025ca6ab745",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xef4495df18ca8f2ac57070b38a3895915ca1d4390002000000000000000000dc",
+        "address": "0xef4495df18ca8f2ac57070b38a3895915ca1d439",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.130006866559853514",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfc248cef4c8763838743d3bd599a27e1bd6397f4",
+                "balance": "0.000000000000958819",
+                "decimals": 18,
+                "weight": "0.870008392462043184",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xfc248cef4c8763838743d3bd599a27e1bd6397f4"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x60f9966807473cd78c9aa59944daf3a73f73da76000200000000000000000140",
+        "address": "0x60f9966807473cd78c9aa59944daf3a73f73da76",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0692f013829a685030ec62f9e20b8cc721f0bd02",
+                "balance": "0.000000000024973434",
+                "decimals": 18,
+                "weight": "0.980010681315327688",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.020004577706569009",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0692f013829a685030ec62f9e20b8cc721f0bd02",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc772e7135a3e32a87e148a4f2f5f7493de0a68e70002000000000000000000a4",
+        "address": "0xc772e7135a3e32a87e148a4f2f5f7493de0a68e7",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.015",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.700007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe93a27d4ed64f44a2b356d78c06115e5c9d97da0",
+                "balance": "0.000000000003998461",
+                "decimals": 18,
+                "weight": "0.300007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xe93a27d4ed64f44a2b356d78c06115e5c9d97da0"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd20f6f1d8a675cdca155cb07b5dc9042c467153f000200000000000000000152",
+        "address": "0xd20f6f1d8a675cdca155cb07b5dc9042c467153f",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.370000762951094835",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfd4168e642ebd04c3684a6cdb3a5e86de85d3908",
+                "balance": "0.000000000011335385",
+                "decimals": 18,
+                "weight": "0.630014496070801862",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xfd4168e642ebd04c3684a6cdb3a5e86de85d3908"
+        ],
+        "totalWeight": "1.000015259720392182",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x57ce7bfb3e3379e1b3a1a1e852e82e775a5c81350002000000000000000001e0",
+        "address": "0x57ce7bfb3e3379e1b3a1a1e852e82e775a5c8135",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x699d2b018369c0c639866551c6a686f081b35d54",
+                "balance": "0.000000000000597989",
+                "decimals": 18,
+                "weight": "0.32951315665690883",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.670502102440897691",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x699d2b018369c0c639866551c6a686f081b35d54",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x925b7a2f056a4c23775eca3397832975fdf3a8610002000000000000000001e1",
+        "address": "0x925b7a2f056a4c23775eca3397832975fdf3a861",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.657611139081280685",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf6c8e4005c631a6934151702a62e9f76fb2a14e9",
+                "balance": "0.000000005",
+                "decimals": 9,
+                "weight": "0.342404120019588561",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xf6c8e4005c631a6934151702a62e9f76fb2a14e9"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x49e067b377c4a84ae956165adf918135f32441b90002000000000000000001d2",
+        "address": "0x49e067b377c4a84ae956165adf918135f32441b9",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x86f24003177c72f54da17bc46cb8dd08c2cd7553",
+                "balance": "0.000000000074922947",
+                "decimals": 18,
+                "weight": "0.100007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.900007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x86f24003177c72f54da17bc46cb8dd08c2cd7553",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x406a295cd75ce1750d8e3c13410273504e8ff9940002000000000000000000ea",
+        "address": "0x406a295cd75ce1750d8e3c13410273504e8ff994",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc7c6a5e251383a69e7c92635bd37e518c7477572",
+                "balance": "0.000000000000487238",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc7c6a5e251383a69e7c92635bd37e518c7477572"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4fda689e34552f15746c720978860b033d721efb0002000000000000000001bf",
+        "address": "0x4fda689e34552f15746c720978860b033d721efb",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x8d4e72880735adcd73b64e8d2124739b3dd3a77a",
+                "balance": "0.000616022770043952",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8d4e72880735adcd73b64e8d2124739b3dd3a77a",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb12f3144f75569b1959f9a9dd8c046a5b7ca75810002000000000000000001a0",
+        "address": "0xb12f3144f75569b1959f9a9dd8c046a5b7ca7581",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x5e9f7e92e742f73b990dca63c88325ed24666e84",
+                "balance": "0.000001727288913261",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5e9f7e92e742f73b990dca63c88325ed24666e84",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xce8d42d9754470ded74042b07521e6a9335716fd0002000000000000000001b7",
+        "address": "0xce8d42d9754470ded74042b07521e6a9335716fd",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x19736bd89ccab90d62b7b3d8efb798c6a04566f7",
+                "balance": "0.000069189879401181",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x19736bd89ccab90d62b7b3d8efb798c6a04566f7",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x34e7677c19d527519eb336d3860f612b9ca107ab0002000000000000000001b0",
+        "address": "0x34e7677c19d527519eb336d3860f612b9ca107ab",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x460a0f76eeea111ae63d972f84fc092afbb83d71",
+                "balance": "0.000004739672079127",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x460a0f76eeea111ae63d972f84fc092afbb83d71",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf9534c93db146a42e7386618da14a3b0124fdef60002000000000000000001cd",
+        "address": "0xf9534c93db146a42e7386618da14a3b0124fdef6",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x63012e61db92247a00eb73c027e9815696d16cc6",
+                "balance": "0.000000000000658326",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x63012e61db92247a00eb73c027e9815696d16cc6",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x791d625aead01e57d1b03ddc99a43b252930c43c0002000000000000000000dd",
+        "address": "0x791d625aead01e57d1b03ddc99a43b252930c43c",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbc6669e7914a2b327ae428184086d8ac88d74efc",
+                "balance": "0.00000000003897849",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xbc6669e7914a2b327ae428184086d8ac88d74efc"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xbb0e7784c902009c9a730837848408d463e7ee9f0002000000000000000001da",
+        "address": "0xbb0e7784c902009c9a730837848408d463e7ee9f",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x529ff59a4423239f07e8114ca83acc674479a94c",
+                "balance": "0.000639839345051316",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x529ff59a4423239f07e8114ca83acc674479a94c",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000000000465661289",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xed86f985bf12cd88cd32735e5e78cda08370ea970002000000000000000001c2",
+        "address": "0xed86f985bf12cd88cd32735e5e78cda08370ea97",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x1340ba6a60edc3b8b71f8759a758ba2e4840f6cc",
+                "balance": "0.000949211578766146",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1340ba6a60edc3b8b71f8759a758ba2e4840f6cc",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6559ca190214f0a7e5927ecd5e2a8711050d8b820002000000000000000001b5",
+        "address": "0x6559ca190214f0a7e5927ecd5e2a8711050d8b82",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x16fdc85833e948c22439b3c690a971d2e0b268c5",
+                "balance": "0.000003307275387148",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x16fdc85833e948c22439b3c690a971d2e0b268c5",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1158c354a702e86a711cedb86806d91cd9a136810002000000000000000001d1",
+        "address": "0x1158c354a702e86a711cedb86806d91cd9a13681",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.035",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x85cae40f368aa01b8f5a5a2f24aa22575fa5c45e",
+                "balance": "0.000000330385709044",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x85cae40f368aa01b8f5a5a2f24aa22575fa5c45e",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000000000465661289",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x773a8b97cce7d9d78df41e5c4fdd536d3cf81d3e000200000000000000000189",
+        "address": "0x773a8b97cce7d9d78df41e5c4fdd536d3cf81d3e",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.0001",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xaf50f8bec1dbec013b7025db444da019c2f5d488",
+                "balance": "0.000000000034952909",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xaf50f8bec1dbec013b7025db444da019c2f5d488"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3965ed15a0bbab8c6292f4a3d9bf3504069877490002000000000000000001d7",
+        "address": "0x3965ed15a0bbab8c6292f4a3d9bf350406987749",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.035",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb45ff0d00882e1cc12d5a9acc183e59b600dc54f",
+                "balance": "0.000175450348177719",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xb45ff0d00882e1cc12d5a9acc183e59b600dc54f"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd1e18b0e5b61c1f529260eb88c49f944cc7060e40002000000000000000001bb",
+        "address": "0xd1e18b0e5b61c1f529260eb88c49f944cc7060e4",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.0314",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x314159261c521f8c70fd0813d34445d63d229ae7",
+                "balance": "0.000174582794582542",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x314159261c521f8c70fd0813d34445d63d229ae7",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb8631c4abc3de0b546f721a9debc5e780985df770002000000000000000001ad",
+        "address": "0xb8631c4abc3de0b546f721a9debc5e780985df77",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x7b52118bcd20d43861cdb112150a9b0342677d3b",
+                "balance": "0.000040666474845335",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7b52118bcd20d43861cdb112150a9b0342677d3b",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xaf966f10f7803bea170fdb5ba17920e36c5a93a30002000000000000000001c6",
+        "address": "0xaf966f10f7803bea170fdb5ba17920e36c5a93a3",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x8a575cb138d634ba0aecff8d77847388e9c4116b",
+                "balance": "0.000000000045201503",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8a575cb138d634ba0aecff8d77847388e9c4116b",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb11102c294d86c33fc917d826ae21480cadb96ed0002000000000000000001ca",
+        "address": "0xb11102c294d86c33fc917d826ae21480cadb96ed",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x8d9ab055db3de0d207a27b0d32cebe23d0a6b822",
+                "balance": "0.000000000130275699",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8d9ab055db3de0d207a27b0d32cebe23d0a6b822",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xdd3b8a0a963f51869df37d270339c33071f2d4280002000000000000000001bd",
+        "address": "0xdd3b8a0a963f51869df37d270339c33071f2d428",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.05",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc1d8debe416364cff6ae83e9387104b46f4a716a",
+                "balance": "0.000000000000866941",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc1d8debe416364cff6ae83e9387104b46f4a716a"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc8045b2c70777fb1b3330310f10b820d06fecea50002000000000000000001c9",
+        "address": "0xc8045b2c70777fb1b3330310f10b820d06fecea5",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x5a27924b49b3c09b05d7c125aa72690008cc4925",
+                "balance": "0.000002844301687807",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5a27924b49b3c09b05d7c125aa72690008cc4925",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xfbbc111b691ba38d03b01bbfa2ac451745f9bca5000200000000000000000114",
+        "address": "0xfbbc111b691ba38d03b01bbfa2ac451745f9bca5",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.08000305180437934",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbd811710cecd57e526b73ba373225787a5f0b41b",
+                "balance": "0.000000000000452412",
+                "decimals": 18,
+                "weight": "0.920012207217517358",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xbd811710cecd57e526b73ba373225787a5f0b41b"
+        ],
+        "totalWeight": "1.000015259720392182",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xef6ae2cc302c8619b6e64616997ef5107962d7ab0002000000000000000000d9",
+        "address": "0xef6ae2cc302c8619b6e64616997ef5107962d7ab",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x4f63e1355b844227ad8a365068697c753fb7e462",
+                "balance": "0.00000000000053",
+                "decimals": 18,
+                "weight": "0.94000152590218967",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.060013733119707027",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x4f63e1355b844227ad8a365068697c753fb7e462",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xbad8de88febc2d9364254e108fe5a547a7b6b4c000020000000000000000012e",
+        "address": "0xbad8de88febc2d9364254e108fe5a547a7b6b4c0",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x618d37b4d27667c34576ffe993a4617eacabe587",
+                "balance": "0.0000000001",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x618d37b4d27667c34576ffe993a4617eacabe587",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259720392182",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x87ba8e328220531a447b44a176267002a343eb1e0002000000000000000001c1",
+        "address": "0x87ba8e328220531a447b44a176267002a343eb1e",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x1340ba6a60edc3b8b71f8759a758ba2e4840f6cc",
+                "balance": "0.000999999999999999",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1340ba6a60edc3b8b71f8759a758ba2e4840f6cc",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7ed087afab0b2653c8137744916ed1aba97e2fa2000200000000000000000124",
+        "address": "0x7ed087afab0b2653c8137744916ed1aba97e2fa2",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x67b0928f8025d8548a4475a80c5444aa8087fdbe",
+                "balance": "0.01",
+                "decimals": 2,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x67b0928f8025d8548a4475a80c5444aa8087fdbe",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x61853f9bfa5a7439836863beceeca9ec34b8a2d10002000000000000000001d4",
+        "address": "0x61853f9bfa5a7439836863beceeca9ec34b8a2d1",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x114e931e44f96dee5afd038ef43bb23426161cf3",
+                "balance": "0.000555555555555555",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x114e931e44f96dee5afd038ef43bb23426161cf3",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1e9142bfd599bdecc03e7963aef0d96947bee845000200000000000000000145",
+        "address": "0x1e9142bfd599bdecc03e7963aef0d96947bee845",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x15b7c0c907e4c6b9adaaaabc300c08991d6cea05",
+                "balance": "0.0000000000006258",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.000001",
+                "decimals": 6,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x15b7c0c907e4c6b9adaaaabc300c08991d6cea05",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x70b18450bd1f9296c38cc36ac1369f51f45b95f8000200000000000000000151",
+        "address": "0x70b18450bd1f9296c38cc36ac1369f51f45b95f8",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.015",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0c3983165e9bce0a9bb43184cc4eebb26dce48fa",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000007933",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0c3983165e9bce0a9bb43184cc4eebb26dce48fa",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb82a45ea7c6d7c90bd95e9e2af13242538f2e26900010000000000000000007a",
+        "address": "0xb82a45ea7c6d7c90bd95e9e2af13242538f2e269",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x114f1388fab456c4ba31b1850b244eedcd024136",
+                "balance": "0.000000000000983972",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
+                "balance": "0.000000000000030766",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x269616d549d7e8eaa82dfb17028d0b212d11232a",
+                "balance": "0.000000000000031934",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x641927e970222b10b2e8cdbc96b1b4f427316f16",
+                "balance": "0.000000000000491956",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000001321145",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd70240dd62f4ea9a6a2416e0073d72139489d2aa",
+                "balance": "0.000000000000006023",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe9f84de264e91529af07fa2c746e934397810334",
+                "balance": "0.000000000000194736",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xea47b64e1bfccb773a0420247c0aa0a3c1d2e5c5",
+                "balance": "0.000000000000097948",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x114f1388fab456c4ba31b1850b244eedcd024136",
+            "0x23b608675a2b2fb1890d3abbd85c5775c51691d5",
+            "0x269616d549d7e8eaa82dfb17028d0b212d11232a",
+            "0x641927e970222b10b2e8cdbc96b1b4f427316f16",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd70240dd62f4ea9a6a2416e0073d72139489d2aa",
+            "0xe9f84de264e91529af07fa2c746e934397810334",
+            "0xea47b64e1bfccb773a0420247c0aa0a3c1d2e5c5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd47c0734a0b5feff3bb2fc8542cd5b9751afeefb000100000000000000000037",
+        "address": "0xd47c0734a0b5feff3bb2fc8542cd5b9751afeefb",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.00000000000000115",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "0.000000000001937069",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+                "balance": "0.000000000001712376",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.000000000000139846",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.000000000000013299",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "0.000000000000121022",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                "balance": "0.000000000004009385",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000017365",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4956d05002bbe857a6b20eb17cbd66da40a5e971000200000000000000000088",
+        "address": "0x4956d05002bbe857a6b20eb17cbd66da40a5e971",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.042",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+                "balance": "0.00000000000010041",
+                "decimals": 18,
+                "weight": "0.040009155413138018",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000076207",
+                "decimals": 18,
+                "weight": "0.960006103608758679",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x88acdd2a6425c3faae4bc9650fd7e27e0bebb7ab",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9212b088d48fc749c5adc573b445bc0d0a289a340002000000000000000000b1",
+        "address": "0x9212b088d48fc749c5adc573b445bc0d0a289a34",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x507586012a126421c3669a64b8393fffa9c44462",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.250003814755474175",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000013557",
+                "decimals": 18,
+                "weight": "0.750011444266422523",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x507586012a126421c3669a64b8393fffa9c44462",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1b46e4b0791c9383b73b64aabc371360a031a83f000200000000000000000057",
+        "address": "0x1b46e4b0791c9383b73b64aabc371360a031a83f",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+                "balance": "0.000000000056683009",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000021541",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb0fba102a03703fe2c1dd6300e7b431eac60e4b6000200000000000000000033",
+        "address": "0xb0fba102a03703fe2c1dd6300e7b431eac60e4b6",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
+                "balance": "0.000000000001388452",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000008422",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x36128d5436d2d70cab39c9af9cce146c38554ff0000200000000000000000009",
+        "address": "0x36128d5436d2d70cab39c9af9cce146c38554ff0",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001048883",
+        "tokens": [
+            {
+                "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+                "balance": "0.00000000000027404",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.000000000001003693",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6810e776880c02933d47db1b9fc05908e5386b96",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xed9eee3a0a98d84ce6bb33ac8bddaed1b5302f020002000000000000000001c4",
+        "address": "0xed9eee3a0a98d84ce6bb33ac8bddaed1b5302f02",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x4d224452801aced8b2f0aebe155379bb5d594381",
+                "balance": "0.000000000006750728",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.00000000000003704",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x4d224452801aced8b2f0aebe155379bb5d594381",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x053f3c35d557a76e9cb6c13a4842d9cfcddac8330002000000000000000000cd",
+        "address": "0x053f3c35d557a76e9cb6c13a4842d9cfcddac833",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x8a14897ea5f668f36671678593fae44ae23b39fb",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000843",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8a14897ea5f668f36671678593fae44ae23b39fb",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xeb58be542e77195355d90100beb07105b9bd295e00010000000000000000003d",
+        "address": "0xeb58be542e77195355d90100beb07105b9bd295e",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "0.000000000001920675",
+                "decimals": 18,
+                "weight": "0.333333333333333333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                "balance": "0.000000000002153364",
+                "decimals": 18,
+                "weight": "0.333333333333333333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000008971",
+                "decimals": 18,
+                "weight": "0.333333333333333334",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x72ab6ff76554f90532e2809cee019ade724e029a000100000000000000000047",
+        "address": "0x72ab6ff76554f90532e2809cee019ade724e029a",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+                "balance": "0.000000000000040336",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
+                "balance": "0.000000000069970947",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+                "balance": "0.000000000000762841",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000003477",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfa5047c9c78b8877af97bdcb85db743fd7313d4a",
+                "balance": "0.000000000000043013",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2ba592f78db6436527729929aaf6c908497cb200",
+            "0x584bc13c7d411c00c01a62e8019472de68768430",
+            "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xfa5047c9c78b8877af97bdcb85db743fd7313d4a"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x571046eae58c783f29f95adba17dd561af8a871200020000000000000000000c",
+        "address": "0x571046eae58c783f29f95adba17dd561af8a8712",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.00000000002859584",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000008809",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3b7f8107de88c75603f3cb9152ce8a4d43910fa80002000000000000000000c6",
+        "address": "0x3b7f8107de88c75603f3cb9152ce8a4d43910fa8",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xbe632e8ae54398563983aea1e36923276dd02529",
+                "balance": "0.000000001",
+                "decimals": 9,
+                "weight": "0.820004577706569009",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000003",
+                "decimals": 18,
+                "weight": "0.180010681315327688",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xbe632e8ae54398563983aea1e36923276dd02529",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x58af920d9dc0bc4e8f771ff013d79215cabcaa9e00010000000000000000005f",
+        "address": "0x58af920d9dc0bc4e8f771ff013d79215cabcaa9e",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e",
+                "balance": "0.000000000000449552",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+                "balance": "0.000000000000021075",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
+                "balance": "0.000000000046267562",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.000000000000151005",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+                "balance": "0.000000000000103077",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+                "balance": "0.000000000000374162",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000001796",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+                "balance": "0.000000000000013944",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e",
+            "0x2ba592f78db6436527729929aaf6c908497cb200",
+            "0x584bc13c7d411c00c01a62e8019472de68768430",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+            "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xdbdb4d16eda451d0503b854cf79d55697f90c8df"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8bda1ab5eead21547ba0f33c07c86c5dc48d9baa00010000000000000000005b",
+        "address": "0x8bda1ab5eead21547ba0f33c07c86c5dc48d9baa",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "0.000000000000446097",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.00000000000000012",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
+                "balance": "0.000000000000078477",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+                "balance": "0.000000000010878465",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+                "balance": "0.000000000002041104",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.000000000000179662",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000001591",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+                "balance": "0.000000000002296408",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
+            "0x408e41876cccdc0f92210600ef50372656052a38",
+            "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd533a949740bb3306d119cc777fa900ba034cd52"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7bf521b4f4c1543a622e11ee347efb1a2374332200010000000000000000005c",
+        "address": "0x7bf521b4f4c1543a622e11ee347efb1a23743322",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e",
+                "balance": "0.000000000000264886",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x2ba592f78db6436527729929aaf6c908497cb200",
+                "balance": "0.000000000000019366",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x584bc13c7d411c00c01a62e8019472de68768430",
+                "balance": "0.000000000038098545",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.000000000000146482",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+                "balance": "0.000000000000319636",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000001206",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+                "balance": "0.000000000000009873",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf5d669627376ebd411e34b98f19c868c8aba5ada",
+                "balance": "0.000000000000563339",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0cec1a9154ff802e7934fc916ed7ca50bde6844e",
+            "0x2ba592f78db6436527729929aaf6c908497cb200",
+            "0x584bc13c7d411c00c01a62e8019472de68768430",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xbc396689893d065f41bc2c6ecbee5e0085233447",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xdbdb4d16eda451d0503b854cf79d55697f90c8df",
+            "0xf5d669627376ebd411e34b98f19c868c8aba5ada"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd208168d2a512240eb82582205d94a0710bce4e7000100000000000000000072",
+        "address": "0xd208168d2a512240eb82582205d94a0710bce4e7",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x1b40183efb4dd766f11bda7a7c3ad8982e998421",
+                "balance": "0.000000000001645096",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba4cfe5741b357fa371b506e5db0774abfecf8fc",
+                "balance": "0.000000000001107938",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000001372",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1b40183efb4dd766f11bda7a7c3ad8982e998421",
+            "0xba4cfe5741b357fa371b506e5db0774abfecf8fc",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x606e3ccc8c51cbbb1ff07ad03c6f95a84672ab16000100000000000000000067",
+        "address": "0x606e3ccc8c51cbbb1ff07ad03c6f95a84672ab16",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "0.000000000000325486",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.000000000000000092",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
+                "balance": "0.000000000000051796",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x408e41876cccdc0f92210600ef50372656052a38",
+                "balance": "0.000000000006661137",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+                "balance": "0.000000000000717078",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000001051",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                "balance": "0.000000000004300601",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+                "balance": "0.000000000001837931",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x0d438f3b5175bebc262bf23753c1e53d03432bde",
+            "0x408e41876cccdc0f92210600ef50372656052a38",
+            "0x5a98fcbea516cf06857215779fd812ca3bef1b32",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+            "0xd533a949740bb3306d119cc777fa900ba034cd52"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xfc157bcfd63f7c59aa04ef2e1e30cbd5c8ebc666000200000000000000000130",
+        "address": "0xfc157bcfd63f7c59aa04ef2e1e30cbd5c8ebc666",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x375abb85c329753b1ba849a601438ae77eec9893",
+                "balance": "0.000000000020018086",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.000000000012276624",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x375abb85c329753b1ba849a601438ae77eec9893",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x59e2563c08029f13f80cba9eb610bfd0367ed266000100000000000000000082",
+        "address": "0x59e2563c08029f13f80cba9eb610bfd0367ed266",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0ec9f76202a7061eb9b3a7d6b59d36215a7e37da",
+                "balance": "0.000000000000535795",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+                "balance": "0.000000000001360394",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+                "balance": "0.000000000000522927",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+                "balance": "0.000000000003824567",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+                "balance": "0.000000000000021571",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+                "balance": "0.000000000000043907",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000894",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb",
+                "balance": "0.000000000000053473",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0ec9f76202a7061eb9b3a7d6b59d36215a7e37da",
+            "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+            "0x25f8087ead173b73d6e8b84329989a8eea16cf73",
+            "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+            "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+            "0xbb0e17ef65f82ab018d8edd776e8dd940327b28b",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xea0b9c466e6c8d344f75ece6c69d99e7e4f86600000200000000000000000040",
+        "address": "0xea0b9c466e6c8d344f75ece6c69d99e7e4f86600",
+        "poolType": "Weighted",
+        "swapFee": "0.1",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa279dab6ec190ee4efce7da72896eb58ad533262",
+                "balance": "0.0000000000250001",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000010001",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa279dab6ec190ee4efce7da72896eb58ad533262",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf93e20844fd084b657d5e71342157b36c5f3032d00020000000000000000003c",
+        "address": "0xf93e20844fd084b657d5e71342157b36c5f3032d",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x01abc00e86c7e258823b9a055fd62ca6cf61a163",
+                "balance": "0.000000000000204171",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.00000000001809477",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x01abc00e86c7e258823b9a055fd62ca6cf61a163",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x991aeafbe1b1c7ac8348dc623ae350768d0c65b3000100000000000000000008",
+        "address": "0x991aeafbe1b1c7ac8348dc623ae350768d0c65b3",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "0.000000000000198916",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+                "balance": "0.000000000000432643",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.000000000000037297",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.000000000000189085",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                "balance": "0.000000000003431301",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc944e90c64b2c07662a292be6244bdf05cda44a7"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xeedca0c2cba983b718c66094fc8e41f9ed52f82a00020000000000000000011c",
+        "address": "0xeedca0c2cba983b718c66094fc8e41f9ed52f82a",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x7f3141c4d6b047fb930991b450f1ed996a51cb26",
+                "balance": "0.000000000342511296",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000001585",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7f3141c4d6b047fb930991b450f1ed996a51cb26",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x021c343c6180f03ce9e48fae3ff432309b9af19900020000000000000000000b",
+        "address": "0x021c343c6180f03ce9e48fae3ff432309b9af199",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000002521",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd291e7a03283640fdc51b121ac401383a46cc623",
+                "balance": "0.000000000001876469",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd291e7a03283640fdc51b121ac401383a46cc623"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xce66904b68f1f070332cbc631de7ee98b650b49900020000000000000000000a",
+        "address": "0xce66904b68f1f070332cbc631de7ee98b650b499",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x36128d5436d2d70cab39c9af9cce146c38554ff0",
+                "balance": "0.000000000000048883",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.0000000000051145",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x36128d5436d2d70cab39c9af9cce146c38554ff0",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x526217f24e8f427fdb369a23f133c8a046e5b04e00020000000000000000019b",
+        "address": "0x526217f24e8f427fdb369a23f133c8a046e5b04e",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000846",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf3b9569f82b18aef890de263b84189bd33ebe452",
+                "balance": "0.000002316160983151",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf3b9569f82b18aef890de263b84189bd33ebe452"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8b568d9ee0f6bc4eb91ece97dfdc8337728613e10002000000000000000000d7",
+        "address": "0x8b568d9ee0f6bc4eb91ece97dfdc8337728613e1",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xaa61d5dec73971cd4a026ef2820bb87b4a4ed8d6",
+                "balance": "0.00000000000374862",
+                "decimals": 18,
+                "weight": "0.780010681315327688",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000129",
+                "decimals": 18,
+                "weight": "0.220004577706569009",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xaa61d5dec73971cd4a026ef2820bb87b4a4ed8d6",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe0b5a96004c2155c377949a74e9d483bbc77fdb7000200000000000000000106",
+        "address": "0xe0b5a96004c2155c377949a74e9d483bbc77fdb7",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x40803cea2b2a32bda1be61d3604af6a814e70976",
+                "balance": "0.000000000000445212",
+                "decimals": 18,
+                "weight": "0.7",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.00000000000065635",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x40803cea2b2a32bda1be61d3604af6a814e70976",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x54b7d8cbb8057c5990ed5a7a94febee61d6b583700020000000000000000016f",
+        "address": "0x54b7d8cbb8057c5990ed5a7a94febee61d6b5837",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x12e457a5fc7707d0fdda849068df6e664d7a8569",
+                "balance": "0.000000000000580011",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000317",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x12e457a5fc7707d0fdda849068df6e664d7a8569",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc931b64e181a4a29416f55e67921bfe16e4fe789000200000000000000000136",
+        "address": "0xc931b64e181a4a29416f55e67921bfe16e4fe789",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x12e56851ec22874520dc4c7fa0a8a8d7dba1bac8",
+                "balance": "0.000000000005655585",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000236",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x12e56851ec22874520dc4c7fa0a8a8d7dba1bac8",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730893",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x99184713bad36bdcbc31453670fbb0d2ec3cfcc400020000000000000000014d",
+        "address": "0x99184713bad36bdcbc31453670fbb0d2ec3cfcc4",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x09f098b155d561fc9f7bccc97038b7e3d20baf74",
+                "balance": "0.000000000002141304",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.000000000000391299",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x09f098b155d561fc9f7bccc97038b7e3d20baf74",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1.000015259720392182",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xbf4f5e87d0b2f9ba735b7ab4e11bc30d65fab991000200000000000000000142",
+        "address": "0xbf4f5e87d0b2f9ba735b7ab4e11bc30d65fab991",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.03",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000116",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xda91e5547cba22e79d0c66bd9040aed90f0363c5",
+                "balance": "0.00000000084117516",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xda91e5547cba22e79d0c66bd9040aed90f0363c5"
+        ],
+        "totalWeight": "1.000015259254730893",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x41175c3ee2dd49fca9b263f49525c069095b87c7000100000000000000000074",
+        "address": "0x41175c3ee2dd49fca9b263f49525c069095b87c7",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x1b40183efb4dd766f11bda7a7c3ad8982e998421",
+                "balance": "0.000000000000005861",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.000000000000050373",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x86ed939b500e121c0c5f493f399084db596dad20",
+                "balance": "0.000000000009352828",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
+                "balance": "0.000000000000011459",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000016",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1b40183efb4dd766f11bda7a7c3ad8982e998421",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x86ed939b500e121c0c5f493f399084db596dad20",
+            "0xa3d58c4e56fedcae3a7c43a725aee9a71f0ece4e",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8175c3893a54238e0f1350075d17c177bf789a240002000000000000000000ff",
+        "address": "0x8175c3893a54238e0f1350075d17c177bf789a24",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x6069c9223e8a5da1ec49ac5525d4bb757af72cd8",
+                "balance": "0.000000000014424917",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000058",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6069c9223e8a5da1ec49ac5525d4bb757af72cd8",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x79ac30cb7eb32842841cae9ba4fc445bba6704c10002000000000000000001a1",
+        "address": "0x79ac30cb7eb32842841cae9ba4fc445bba6704c1",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000003",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd40061626a783d43dc5dcdf4c2bff10d3f81d551",
+                "balance": "0.000664716087532499",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd40061626a783d43dc5dcdf4c2bff10d3f81d551"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x90a310c2f53b3acc366100d0957f57a660a71a6b0002000000000000000001a4",
+        "address": "0x90a310c2f53b3acc366100d0957f57a660a71a6b",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xa7535993ca958131995d892d598b638e278dd592",
+                "balance": "0.000535299261389637",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000023",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa7535993ca958131995d892d598b638e278dd592",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd5167d330ff8680af8119d32b786ac2ff2a2be360002000000000000000001a9",
+        "address": "0xd5167d330ff8680af8119d32b786ac2ff2a2be36",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.000025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xabd141c0c87c83b4337818f731954ce836872614",
+                "balance": "0.000333333333333333",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000001",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xabd141c0c87c83b4337818f731954ce836872614",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7e49f73a5b8c62f4c5792dcd23efb03ec35285850002000000000000000001ae",
+        "address": "0x7e49f73a5b8c62f4c5792dcd23efb03ec3528585",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.03",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x84eee6cabcdbdf13c0442d1f7044f2f1020f82c2",
+                "balance": "0.000000020175390876",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000017",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x84eee6cabcdbdf13c0442d1f7044f2f1020f82c2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0a0b9f36c6448f571e0d8f91d67980852cf126e90002000000000000000001a5",
+        "address": "0x0a0b9f36c6448f571e0d8f91d67980852cf126e9",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.025",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000003",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe2a20f757f5d75d6a751320d0cc30067ef8565fd",
+                "balance": "0.000879060173769399",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xe2a20f757f5d75d6a751320d0cc30067ef8565fd"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf87f3b47182e8a13082bc9c347bce7ca5afd67180002000000000000000000e3",
+        "address": "0xf87f3b47182e8a13082bc9c347bce7ca5afd6718",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x7f5ceeb90f15766ca8e70e09ae86946f1da1ad1f",
+                "balance": "0.000000000000998885",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000001",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7f5ceeb90f15766ca8e70e09ae86946f1da1ad1f",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x37a4d0f6a7f4fd0684076b951a1b996a84dbfca90002000000000000000001a7",
+        "address": "0x37a4d0f6a7f4fd0684076b951a1b996a84dbfca9",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x13948b020f2350b261b8388881e55c12f6719145",
+                "balance": "0.000004105531492027",
+                "decimals": 18,
+                "weight": "0.68000305180437934",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.000000000000000001",
+                "decimals": 18,
+                "weight": "0.320012207217517358",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x13948b020f2350b261b8388881e55c12f6719145",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259254730894",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6de69beb66317557e65168bd7d3fff22a89dbb11000200000000000000000056",
+        "address": "0x6de69beb66317557e65168bd7d3fff22a89dbb11",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "0.000000000000000341",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.000000000000000132",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x94be72dc46fe8f7e9f40fbd2c31826f472f4036e",
+                "balance": "0.00000000000000021",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x94be72dc46fe8f7e9f40fbd2c31826f472f4036e"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1624831814",
+        "unitSeconds": "788923800",
+        "principalToken": "0x94be72dc46fe8f7e9f40fbd2c31826f472f4036e",
+        "baseToken": "0x6b175474e89094c44da98b954eedeac495271d0f",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xfaeb6a8b5f15af77673666e51a44f6b9b6ca5da200020000000000000000012c",
+        "address": "0xfaeb6a8b5f15af77673666e51a44f6b9b6ca5da2",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.0",
+                "decimals": 8,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x6b175474e89094c44da98b954eedeac495271d0f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf94a7df264a2ec8bceef2cfe54d7ca3f6c6dfc7a000200000000000000000064",
+        "address": "0xf94a7df264a2ec8bceef2cfe54d7ca3f6c6dfc7a",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.04276553537164692",
+        "tokens": [
+            {
+                "address": "0xc080f19d9e7ccb6ef2096dfa08570e0057490940",
+                "balance": "0.195736411469303793",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf",
+                "balance": "0.002346581297097566",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc080f19d9e7ccb6ef2096dfa08570e0057490940",
+            "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf6dc4640d2783654bef88e0df3fb0f051f0dfc1a00020000000000000000007e",
+        "address": "0xf6dc4640d2783654bef88e0df3fb0f051f0dfc1a",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "5.119160396099675107",
+        "tokens": [
+            {
+                "address": "0x9cf2ab51ac93711ec2fa32ec861349568a16c729",
+                "balance": "2.200479912200126071",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc4ad29ba4b3c580e6d59105fff484999997675ff",
+                "balance": "3.004914258209096122",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x9cf2ab51ac93711ec2fa32ec861349568a16c729",
+            "0xc4ad29ba4b3c580e6d59105fff484999997675ff"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1636746083",
+        "unitSeconds": "140112867",
+        "principalToken": "0x9cf2ab51ac93711ec2fa32ec861349568a16c729",
+        "baseToken": "0xc4ad29ba4b3c580e6d59105fff484999997675ff",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf643b222334d6950b9c2c6686397d1bed9bdf3f3000100000000000000000170",
+        "address": "0xf643b222334d6950b9c2c6686397d1bed9bdf3f3",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.15",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.55",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.15",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.15",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf3a605da753e9de545841de10ea8bffbd1da9c75000200000000000000000035",
+        "address": "0xf3a605da753e9de545841de10ea8bffbd1da9c75",
+        "poolType": "Weighted",
+        "swapFee": "0.002",
+        "totalShares": "623988.540837532930002099",
+        "tokens": [
+            {
+                "address": "0x478bbc744811ee8310b461514bdc29d03739084d",
+                "balance": "390977.799353659189905888",
+                "decimals": 18,
+                "weight": "0.9",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+                "balance": "43235.292367493534914995",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x478bbc744811ee8310b461514bdc29d03739084d",
+            "0xd533a949740bb3306d119cc777fa900ba034cd52"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf33a6b68d2f6ae0353746c150757e4c494e02366000200000000000000000117",
+        "address": "0xf33a6b68d2f6ae0353746c150757e4c494e02366",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "292569.896067884702731532",
+        "tokens": [
+            {
+                "address": "0x13c99770694f07279607a6274f28a28c33086424",
+                "balance": "975727.810073381182841637",
+                "decimals": 18,
+                "weight": "0.7",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe6fd75ff38adca4b97fbcd938c86b98772431867",
+                "balance": "1777.439824444209503632",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x13c99770694f07279607a6274f28a28c33086424",
+            "0xe6fd75ff38adca4b97fbcd938c86b98772431867"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xf099b7c3bd5a221aa34cb83004a50d66b0189ad0000100000000000000000070",
+        "address": "0xf099b7c3bd5a221aa34cb83004a50d66b0189ad0",
+        "poolType": "Weighted",
+        "swapFee": "0.03",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf5d669627376ebd411e34b98f19c868c8aba5ada",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+            "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+            "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+            "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+            "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf5d669627376ebd411e34b98f19c868c8aba5ada"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xef123b9e0485d837281342af27012c54bbc0d26100020000000000000000003f",
+        "address": "0xef123b9e0485d837281342af27012c54bbc0d261",
+        "poolType": "Weighted",
+        "swapFee": "0.1",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xede4efcc5492cf41ed3f0109d60bc0543cfad23a0002000000000000000000bb",
+        "address": "0xede4efcc5492cf41ed3f0109d60bc0543cfad23a",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+                "balance": "0.000000000099272673",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+                "balance": "0.000000000001001777",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+            "0x956f47f50a910163d8bf957cf5846d573e7f87ca"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe8075304a388f2f9b2af61f502741a88ff21d9a400020000000000000000006b",
+        "address": "0xe8075304a388f2f9b2af61f502741a88ff21d9a4",
+        "poolType": "Weighted",
+        "swapFee": "0.0017609",
+        "totalShares": "16568.308487401245324464",
+        "tokens": [
+            {
+                "address": "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
+                "balance": "105034.099075562857610562",
+                "decimals": 18,
+                "weight": "0.6",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb81d70802a816b5dacba06d708b5acf19dcd436d",
+                "balance": "183.495310306396699229",
+                "decimals": 18,
+                "weight": "0.4",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x94ec4e3a7c5068ae4a035f702f2cd5a6da9c5cc1",
+            "0xb81d70802a816b5dacba06d708b5acf19dcd436d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xe2cd73cfeb471f9f2b08a18afbc87ff2324ef24e000200000000000000000058",
+        "address": "0xe2cd73cfeb471f9f2b08a18afbc87ff2324ef24e",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "5.81583235755718518",
+        "tokens": [
+            {
+                "address": "0xd6fd2f39ff3f3565d456bb8aa94703fe5fd88d33",
+                "balance": "1.966755766815699744",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "4.30964996166152357",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xd6fd2f39ff3f3565d456bb8aa94703fe5fd88d33",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xde620bb8be43ee54d7aa73f8e99a7409fe51108400020000000000000000005d",
+        "address": "0xde620bb8be43ee54d7aa73f8e99a7409fe511084",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "34098.121823808256591316",
+        "tokens": [
+            {
+                "address": "0xbabd64a87881d8df7680907fcde176ff11fa0292",
+                "balance": "110815.334229270242709839",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "2640.478445243254886033",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xbabd64a87881d8df7680907fcde176ff11fa0292",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xdb1db6e248d7bb4175f6e5a382d0a03fe3dcc81300010000000000000000006f",
+        "address": "0xdb1db6e248d7bb4175f6e5a382d0a03fe3dcc813",
+        "poolType": "Weighted",
+        "swapFee": "0.03",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf5d669627376ebd411e34b98f19c868c8aba5ada",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x18aaa7115705e8be94bffebde57af9bfc265b998",
+            "0x3845badade8e6dff049820680d1f14bd3903a5d0",
+            "0x72e364f2abdc788b7e918bc238b21f109cd634d7",
+            "0x87d73e916d7057945c9bcd8cdd94e42a6f47f776",
+            "0xb6ca7399b4f9ca56fc27cbff44f4d2e4eef1fc81",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xf5d669627376ebd411e34b98f19c868c8aba5ada"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd9b84f68af362159da621473ef0f979709734db6000100000000000000000115",
+        "address": "0xd9b84f68af362159da621473ef0f979709734db6",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x13c99770694f07279607a6274f28a28c33086424",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.7",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.15",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.15",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x13c99770694f07279607a6274f28a28c33086424",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd997f35c9b1281b82c8928039d14cddab5e13c2000000000000000000000019c",
+        "address": "0xd997f35c9b1281b82c8928039d14cddab5e13c20",
+        "poolType": "StablePhantom",
+        "swapFee": "0.0001",
+        "totalShares": "440.908593060102459665",
+        "tokens": [
+            {
+                "address": "0x8f4063446f5011bc1c9f79a819efe87776f23704",
+                "balance": "152.150769762942109065",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb0f75e97a114a4eb4a425edc48990e6760726709",
+                "balance": "136.979867457048836011",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc8c79fcd0e859e7ec81118e91ce8e4379a481ee6",
+                "balance": "151.778999546827034301",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd997f35c9b1281b82c8928039d14cddab5e13c20",
+                "balance": "5192296858534386.71993743622676043",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x8f4063446f5011bc1c9f79a819efe87776f23704",
+            "0xb0f75e97a114a4eb4a425edc48990e6760726709",
+            "0xc8c79fcd0e859e7ec81118e91ce8e4379a481ee6",
+            "0xd997f35c9b1281b82c8928039d14cddab5e13c20"
+        ],
+        "totalWeight": "0",
+        "amp": "500.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd921811bdeb2fd219e08bcc30b7918ae62cfee6000010000000000000000018b",
+        "address": "0xd921811bdeb2fd219e08bcc30b7918ae62cfee60",
+        "poolType": "Weighted",
+        "swapFee": "0.0042",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba5bde662c17e2adff1075610382b9b691296350",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xba5bde662c17e2adff1075610382b9b691296350",
+            "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+            "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+            "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+            "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+            "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd8833594420db3d6589c1098dbdd073f52419dba000100000000000000000134",
+        "address": "0xd8833594420db3d6589c1098dbdd073f52419dba",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "1.000633368063451909",
+        "tokens": [
+            {
+                "address": "0x114f1388fab456c4ba31b1850b244eedcd024136",
+                "balance": "1.208206543300849654",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x269616d549d7e8eaa82dfb17028d0b212d11232a",
+                "balance": "0.094418313974086074",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe1406825186d63980fd6e2ec61888f7b91c4bae4",
+                "balance": "0.82418263301729448",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xea47b64e1bfccb773a0420247c0aa0a3c1d2e5c5",
+                "balance": "0.047006484073489578",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x114f1388fab456c4ba31b1850b244eedcd024136",
+            "0x269616d549d7e8eaa82dfb17028d0b212d11232a",
+            "0xe1406825186d63980fd6e2ec61888f7b91c4bae4",
+            "0xea47b64e1bfccb773a0420247c0aa0a3c1d2e5c5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd5d7bc115b32ad1449c6d0083e43c87be95f280900020000000000000000006c",
+        "address": "0xd5d7bc115b32ad1449c6d0083e43c87be95f2809",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "3.165774246774161325",
+        "tokens": [
+            {
+                "address": "0x06325440d014e39736583c165c2963ba99faf14e",
+                "balance": "0.136833989896640343",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x94046274b5aa816ab236a9eab42b5563b56e1931",
+                "balance": "18.331093996279606462",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x06325440d014e39736583c165c2963ba99faf14e",
+            "0x94046274b5aa816ab236a9eab42b5563b56e1931"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd57b0ee9e080e3f6aa0c30bae98234359e97ea98000100000000000000000032",
+        "address": "0xd57b0ee9e080e3f6aa0c30bae98234359e97ea98",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x111111111117dc0aa78b770fa6a738034120c302",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x8798249c2e607446efb7ad49ec89dd1865ff4272",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x111111111117dc0aa78b770fa6a738034120c302",
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x8798249c2e607446efb7ad49ec89dd1865ff4272",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd1d9b4bafc40ef176cda387b10cf03b0fcaad9d8000200000000000000000099",
+        "address": "0xd1d9b4bafc40ef176cda387b10cf03b0fcaad9d8",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd16847480d6bc218048cd31ad98b63cc34e5c2bf00020000000000000000007d",
+        "address": "0xd16847480d6bc218048cd31ad98b63cc34e5c2bf",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "1.268193122923495506",
+        "tokens": [
+            {
+                "address": "0x4f4500b3885bc72199373abfe7adefd0366bafed",
+                "balance": "3.285129819004742115",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc4ad29ba4b3c580e6d59105fff484999997675ff",
+                "balance": "0.122630086730887701",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x4f4500b3885bc72199373abfe7adefd0366bafed",
+            "0xc4ad29ba4b3c580e6d59105fff484999997675ff"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xd0e43c99c05271fa9fdf82281d4d1831a47be81f00020000000000000000003e",
+        "address": "0xd0e43c99c05271fa9fdf82281d4d1831a47be81f",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xce16e7ed7654a3453e8faf748f2c82e57069278f00020000000000000000006d",
+        "address": "0xce16e7ed7654a3453e8faf748f2c82e57069278f",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "5.328736375932750841",
+        "tokens": [
+            {
+                "address": "0x06325440d014e39736583c165c2963ba99faf14e",
+                "balance": "1.071534825414867791",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x26941c63f4587796abe199348ecd3d7c44f9ae0c",
+                "balance": "4.296933449700181896",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x06325440d014e39736583c165c2963ba99faf14e",
+            "0x26941c63f4587796abe199348ecd3d7c44f9ae0c"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1634325622",
+        "unitSeconds": "823636447",
+        "principalToken": "0x26941c63f4587796abe199348ecd3d7c44f9ae0c",
+        "baseToken": "0x06325440d014e39736583c165c2963ba99faf14e",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc9ad279994980f8df348b526901006972509677f00020000000000000000009e",
+        "address": "0xc9ad279994980f8df348b526901006972509677f",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "6011.593359327042192734",
+        "tokens": [
+            {
+                "address": "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+                "balance": "2972.298713181660545824",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x55096a35bf827919b3bb0a5e6b5e2af8095f3d4d",
+                "balance": "3093.121694749931859647",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+            "0x55096a35bf827919b3bb0a5e6b5e2af8095f3d4d"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1643382460",
+        "unitSeconds": "350282167",
+        "principalToken": "0x55096a35bf827919b3bb0a5e6b5e2af8095f3d4d",
+        "baseToken": "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc8c79fcd0e859e7ec81118e91ce8e4379a481ee6000000000000000000000196",
+        "address": "0xc8c79fcd0e859e7ec81118e91ce8e4379a481ee6",
+        "poolType": "ERC4626Linear",
+        "swapFee": "0.0002",
+        "totalShares": "151.778999546827034301",
+        "tokens": [
+            {
+                "address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+                "balance": "151.778999546827034301",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc8c79fcd0e859e7ec81118e91ce8e4379a481ee6",
+                "balance": "5192296858534675.849530949502185794",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf486608dbc7dd0eb80e4b9fa0fdb03e40f414030",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.0"
+            }
+        ],
+        "tokensList": [
+            "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+            "0xc8c79fcd0e859e7ec81118e91ce8e4379a481ee6",
+            "0xf486608dbc7dd0eb80e4b9fa0fdb03e40f414030"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 2,
+        "mainIndex": 0,
+        "lowerTarget": "0.0",
+        "upperTarget": "5000000.0"
+    },
+    {
+        "id": "0xc35bdda2e93c401c6645e0d8a0b2c86906c51710000200000000000000000111",
+        "address": "0xc35bdda2e93c401c6645e0d8a0b2c86906c51710",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.003",
+        "totalShares": "6783138.047131745702873352",
+        "tokens": [
+            {
+                "address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+                "balance": "87299.451631599396366163",
+                "decimals": 18,
+                "weight": "0.100007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc7283b66eb1eb5fb86327f08e1b5816b0720212b",
+                "balance": "2078590.165271765205874442",
+                "decimals": 18,
+                "weight": "0.900007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+            "0xc7283b66eb1eb5fb86327f08e1b5816b0720212b"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xc1382fe6e17bcdbc3d35f73f5317fbf261ebeecd0002000000000000000000a9",
+        "address": "0xc1382fe6e17bcdbc3d35f73f5317fbf261ebeecd",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+                "balance": "0.000000000000028299",
+                "decimals": 18,
+                "weight": "0.010009918364232853",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc7283b66eb1eb5fb86327f08e1b5816b0720212b",
+                "balance": "0.000000000002788461",
+                "decimals": 18,
+                "weight": "0.990005340657663844",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x956f47f50a910163d8bf957cf5846d573e7f87ca",
+            "0xc7283b66eb1eb5fb86327f08e1b5816b0720212b"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb5152e7b85e9c2a9cef95879ee67cfa19da13b1f00020000000000000000015b",
+        "address": "0xb5152e7b85e9c2a9cef95879ee67cfa19da13b1f",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x27c70cd1946795b66be9d954418546998b546634",
+                "balance": "0.000000000000030449",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x8987a07ba83607a66c7351266e771fb865c9ca6c",
+                "balance": "0.000000000008296185",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x27c70cd1946795b66be9d954418546998b546634",
+            "0x8987a07ba83607a66c7351266e771fb865c9ca6c"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb0f75e97a114a4eb4a425edc48990e6760726709000000000000000000000198",
+        "address": "0xb0f75e97a114a4eb4a425edc48990e6760726709",
+        "poolType": "ERC4626Linear",
+        "swapFee": "0.0002",
+        "totalShares": "136.979867457048836011",
+        "tokens": [
+            {
+                "address": "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+                "balance": "136.979867457048836011",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x83e556baea9b5fa5f131bc89a4c7282ca240b156",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1.0"
+            },
+            {
+                "address": "0xb0f75e97a114a4eb4a425edc48990e6760726709",
+                "balance": "5192296858534690.648663039280384084",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5f98805a4e8be255a32880fdec7f6728c6568ba0",
+            "0x83e556baea9b5fa5f131bc89a4c7282ca240b156",
+            "0xb0f75e97a114a4eb4a425edc48990e6760726709"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 1,
+        "mainIndex": 0,
+        "lowerTarget": "0.0",
+        "upperTarget": "5000000.0"
+    },
+    {
+        "id": "0xb07021eb8707b18c7d120e3391aadb260c45fdc200020000000000000000016d",
+        "address": "0xb07021eb8707b18c7d120e3391aadb260c45fdc2",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xaf5191b0de278c7286d6c7cc6ab6bb8a73ba2cd6"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xb03c6b351a283bc1cd26b9cf6d7b0c4556013bdb0002000000000000000000ab",
+        "address": "0xb03c6b351a283bc1cd26b9cf6d7b0c4556013bdb",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "506.870371487120231715",
+        "tokens": [
+            {
+                "address": "0x06325440d014e39736583c165c2963ba99faf14e",
+                "balance": "155.859520085932852039",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x2361102893ccabfb543bc55ac4cc8d6d0824a67e",
+                "balance": "355.300697132798348509",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x06325440d014e39736583c165c2963ba99faf14e",
+            "0x2361102893ccabfb543bc55ac4cc8d6d0824a67e"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1650025565",
+        "unitSeconds": "1166976085",
+        "principalToken": "0x2361102893ccabfb543bc55ac4cc8d6d0824a67e",
+        "baseToken": "0x06325440d014e39736583c165c2963ba99faf14e",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa8d4433badaa1a35506804b43657b0694dea928d00020000000000000000005e",
+        "address": "0xa8d4433badaa1a35506804b43657b0694dea928d",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "365804.746918094075972716",
+        "tokens": [
+            {
+                "address": "0x9b44ed798a10df31dee52c5256dcb4754bcf097e",
+                "balance": "288538.392748839168475421",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "80883.433505027363114755",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x9b44ed798a10df31dee52c5256dcb4754bcf097e",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1632834462",
+        "unitSeconds": "504911232",
+        "principalToken": "0x9b44ed798a10df31dee52c5256dcb4754bcf097e",
+        "baseToken": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa5aeb7b7a40aec3fc6d30eb3ee1431b1e01d2d43000200000000000000000184",
+        "address": "0xa5aeb7b7a40aec3fc6d30eb3ee1431b1e01d2d43",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed1480d12be41d92f36f5f7bdd88212e381a3677",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xed1480d12be41d92f36f5f7bdd88212e381a3677"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa5533a44d06800eaf2daad5aad3f9aa9e1dc36140002000000000000000001b8",
+        "address": "0xa5533a44d06800eaf2daad5aad3f9aa9e1dc3614",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "5247496.662816060728634781",
+        "tokens": [
+            {
+                "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+                "balance": "85588.715153653798027156",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x90b831fa3bebf58e9744a14d638e25b4ee06f9bc",
+                "balance": "6176408.250468965060332673",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+            "0x90b831fa3bebf58e9744a14d638e25b4ee06f9bc"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0xa0488d89fb8d3085d83ad2426b94b9715cf0286900020000000000000000002f",
+        "address": "0xa0488d89fb8d3085d83ad2426b94b9715cf02869",
+        "poolType": "Weighted",
+        "swapFee": "0.0015707963",
+        "totalShares": "6.399917809049309291",
+        "tokens": [
+            {
+                "address": "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
+                "balance": "1167.709592203635878129",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.008824472925100766",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0e29e5abbb5fd88e28b2d355774e73bd47de3bcd",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x9f19a375709baf0e8e35c2c5c65aca676c4c719100000000000000000000006e",
+        "address": "0x9f19a375709baf0e8e35c2c5c65aca676c4c7191",
+        "poolType": "Stable",
+        "swapFee": "0.0005",
+        "totalShares": "255",
+        "tokens": [
+            {
+                "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+                "balance": "85.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd71ecff9342a5ced620049e616c5035f1db98620",
+                "balance": "85.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdb25f211ab05b1c97d595516f45794528a807ad8",
+                "balance": "85.0",
+                "decimals": 2,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+            "0xd71ecff9342a5ced620049e616c5035f1db98620",
+            "0xdb25f211ab05b1c97d595516f45794528a807ad8"
+        ],
+        "totalWeight": "0",
+        "amp": "200.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x94c476e4675faac1bf60211c5e39486bcf720cbd0002000000000000000000a3",
+        "address": "0x94c476e4675faac1bf60211c5e39486bcf720cbd",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "92.256008199996326962",
+        "tokens": [
+            {
+                "address": "0x418de6227499181b045cadf554030722e460881a",
+                "balance": "92.83247909449862255",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+                "balance": "1.022510010692274829",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x418de6227499181b045cadf554030722e460881a",
+            "0x5a6a4d54456819380173272a5e8e9b9904bdf41b"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1644601070",
+        "unitSeconds": "175141084",
+        "principalToken": "0x418de6227499181b045cadf554030722e460881a",
+        "baseToken": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x92e244b931bd6c71c1db2e50326480a0ba530fc700020000000000000000015c",
+        "address": "0x92e244b931bd6c71c1db2e50326480a0ba530fc7",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+                "balance": "0.000000000000054223",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x3ae962fc1d3f2c4890237e4fe04dfe3a7eab94e5",
+                "balance": "0.000000000004798428",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+            "0x3ae962fc1d3f2c4890237e4fe04dfe3a7eab94e5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x92cdaf1995e20c9ce7e20ab02385fca8ce5edc12000200000000000000000161",
+        "address": "0x92cdaf1995e20c9ce7e20ab02385fca8ce5edc12",
+        "poolType": "Weighted",
+        "swapFee": "0.005",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x9c4a4204b79dd291d6b6571c5be8bbcd0622f050"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40000200000000000000000182",
+        "address": "0x92762b42a06dcdddc5b7362cfb01e631c4d44b40",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "408223.409243841591814943",
+        "tokens": [
+            {
+                "address": "0x6810e776880c02933d47db1b9fc05908e5386b96",
+                "balance": "6469.216154461343190088",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab",
+                "balance": "6592121.992019545425500837",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x6810e776880c02933d47db1b9fc05908e5386b96",
+            "0xdef1ca1fb7fbcdc777520aa7f396b4e015f497ab"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8e9d636bbe6939bd0f52849afc02c0c66f6a3603000200000000000000000104",
+        "address": "0x8e9d636bbe6939bd0f52849afc02c0c66f6a3603",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "41366.709943118265181736",
+        "tokens": [
+            {
+                "address": "0x594b1aba4ed1ecc32a012f85527415a470a5352a",
+                "balance": "173070.331354183006170706",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "2474.420745687340449742",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x594b1aba4ed1ecc32a012f85527415a470a5352a",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8b03b2416a336a49ee7e2eb9e4248893f9d0ad54000100000000000000000125",
+        "address": "0x8b03b2416a336a49ee7e2eb9e4248893f9d0ad54",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.3333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.3334",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.3333",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x893b30574bf183d69413717f30b17062ec9dfd8b000200000000000000000061",
+        "address": "0x893b30574bf183d69413717f30b17062ec9dfd8b",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "99298.093096212524368418",
+        "tokens": [
+            {
+                "address": "0xa2b3d083aa1eaa8453bfb477f062a208ed85cbbf",
+                "balance": "66582.376800333386286604",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "34626.856122394966333042",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa2b3d083aa1eaa8453bfb477f062a208ed85cbbf",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1640620258",
+        "unitSeconds": "757366848",
+        "principalToken": "0xa2b3d083aa1eaa8453bfb477f062a208ed85cbbf",
+        "baseToken": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x827ad315960f5a0f5280d6936c8e52a5878bba040001000000000000000000f3",
+        "address": "0x827ad315960f5a0f5280d6936c8e52a5878bba04",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "255031.692603654324898107",
+        "tokens": [
+            {
+                "address": "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+                "balance": "36126.504497656153249327",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+                "balance": "133033.826245801240318031",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+                "balance": "70822.002377416011855769",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c",
+                "balance": "49917.581187815276359459",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0f5d2fb29fb7d3cfee444a200298f468908cc942",
+            "0x967da4048cd07ab37855c090aaf366e4ce1b9f48",
+            "0xbbbbca6a901c926f240b89eacb641d8aec7aeafd",
+            "0xf629cbd94d3791c9250152bd8dfbdf380e2a3b9c"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x802d0f2f4b5f1fb5bfc9b2040a703c1464e1d4cb00020000000000000000009d",
+        "address": "0x802d0f2f4b5f1fb5bfc9b2040a703c1464e1d4cb",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "25603.991720776355749139",
+        "tokens": [
+            {
+                "address": "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+                "balance": "2414.239152421209099273",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x782be9330969aa7b9db56382752a1364580f199f",
+                "balance": "68023.707547674525134325",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+            "0x782be9330969aa7b9db56382752a1364580f199f"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x8028861545e40528bdb47fccd3a6a21fb221ee7a0002000000000000000000a1",
+        "address": "0x8028861545e40528bdb47fccd3a6a21fb221ee7a",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7f0c39e7728f65efe87752b26591006c49d1c200000200000000000000000192",
+        "address": "0x7f0c39e7728f65efe87752b26591006c49d1c200",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.99",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.01",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x7e51bbf45a0cb76ef972ade3e9ff7fa949e05552000200000000000000000120",
+        "address": "0x7e51bbf45a0cb76ef972ade3e9ff7fa949e05552",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x04fa0d235c4abf4bcf4787af4cf447de572ef828",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x75a2c6140536696bb001e42cb2c0d2441527def60002000000000000000001b4",
+        "address": "0x75a2c6140536696bb001e42cb2c0d2441527def6",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xb940fd6455b51f8a19e827e70748e1dbd9f3d4c8",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xb940fd6455b51f8a19e827e70748e1dbd9f3d4c8"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x70b7d3b3209a59fb0400e17f67f3ee8c37363f4900020000000000000000018f",
+        "address": "0x70b7d3b3209a59fb0400e17f67f3ee8c37363f49",
+        "poolType": "Weighted",
+        "swapFee": "0.0001",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7b50775383d3d6f0215a8f290f2c9e2eebbeceb2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6fe95fafe2f86158c77bf18350672d360bfc78a20002000000000000000000bd",
+        "address": "0x6fe95fafe2f86158c77bf18350672d360bfc78a2",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "29.150217362524762913",
+        "tokens": [
+            {
+                "address": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+                "balance": "3.104750740479669415",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x83c32857df72019bc71264ea8e3e06c3031641a2",
+                "balance": "68.553117297499028428",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+            "0x83c32857df72019bc71264ea8e3e06c3031641a2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6f57329d43f3de9ff39d4424576db920b55060b3000100000000000000000126",
+        "address": "0x6f57329d43f3de9ff39d4424576db920b55060b3",
+        "poolType": "Weighted",
+        "swapFee": "0.001",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.3333",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.3334",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.3333",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6f458fea92c5c721c3115ed295e0448abefecb4f0002000000000000000001cc",
+        "address": "0x6f458fea92c5c721c3115ed295e0448abefecb4f",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.02",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x889de83feaeaa1b99a5e073309c296fc71cd928b",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.960006103608758679",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.040009155413138018",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x889de83feaeaa1b99a5e073309c296fc71cd928b",
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+        ],
+        "totalWeight": "1.000015259021896697",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6dd0f7c8f4793ed2531c0df4fea8633a21fdcff40002000000000000000000b7",
+        "address": "0x6dd0f7c8f4793ed2531c0df4fea8633a21fdcff4",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "136.226506134606662168",
+        "tokens": [
+            {
+                "address": "0x285328906d0d33cb757c1e471f5e2176683247c2",
+                "balance": "69.346110353574183557",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc4ad29ba4b3c580e6d59105fff484999997675ff",
+                "balance": "69.944062740993245493",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x285328906d0d33cb757c1e471f5e2176683247c2",
+            "0xc4ad29ba4b3c580e6d59105fff484999997675ff"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1651240496",
+        "unitSeconds": "412133793",
+        "principalToken": "0x285328906d0d33cb757c1e471f5e2176683247c2",
+        "baseToken": "0xc4ad29ba4b3c580e6d59105fff484999997675ff",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x6ac02ecd0c2a23b11f9afb3b3aaf237169475cac0002000000000000000000a8",
+        "address": "0x6ac02ecd0c2a23b11f9afb3b3aaf237169475cac",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "16718.961985495822246714",
+        "tokens": [
+            {
+                "address": "0x194ebd173f6cdace046c53eacce9b953f28411d1",
+                "balance": "7887.132692646286968072",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x2a8f5649de50462ff9699ccc75a2fb0b53447503",
+                "balance": "8978.095875798269957426",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x194ebd173f6cdace046c53eacce9b953f28411d1",
+            "0x2a8f5649de50462ff9699ccc75a2fb0b53447503"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1644604852",
+        "unitSeconds": "349966598",
+        "principalToken": "0x2a8f5649de50462ff9699ccc75a2fb0b53447503",
+        "baseToken": "0x194ebd173f6cdace046c53eacce9b953f28411d1",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x69a074834a8923ddc4908275596bb0c49f476017000100000000000000000191",
+        "address": "0x69a074834a8923ddc4908275596bb0c49f476017",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+                "balance": "0.0",
+                "decimals": 8,
+                "weight": "0.14",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x418d75f65a02b3d53b2418fb8e1fe493759c7605",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.14",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.14",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x85f138bfee4ef8e540890cfb48f620571d67eda3",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.14",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xbd31ea8212119f94a611fa969881cba3ea06fa3d",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.14",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.16",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd31a59c85ae9d8edefec411d448f90841571b89c",
+                "balance": "0.0",
+                "decimals": 9,
+                "weight": "0.14",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
+            "0x418d75f65a02b3d53b2418fb8e1fe493759c7605",
+            "0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+            "0x85f138bfee4ef8e540890cfb48f620571d67eda3",
+            "0xbd31ea8212119f94a611fa969881cba3ea06fa3d",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xd31a59c85ae9d8edefec411d448f90841571b89c"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x67f8fcb9d3c463da05de1392efdbb2a87f8599ea000200000000000000000060",
+        "address": "0x67f8fcb9d3c463da05de1392efdbb2a87f8599ea",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "31435.790236245938172969",
+        "tokens": [
+            {
+                "address": "0xba8c8b50ecd5b580f464f7611b8549ffee4d8da2",
+                "balance": "81422.776128062352816795",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "3054.738697778445825757",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xba8c8b50ecd5b580f464f7611b8549ffee4d8da2",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x64aca7d9d6f1be160f49a8e573965769071dd059000200000000000000000098",
+        "address": "0x64aca7d9d6f1be160f49a8e573965769071dd059",
+        "poolType": "LiquidityBootstrapping",
+        "swapFee": "0.01",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.500007629510948349",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1.000015259021896698",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x63e9b50dd3eb63bfbf93b26f57b9efb574e595760002000000000000000000cf",
+        "address": "0x63e9b50dd3eb63bfbf93b26f57b9efb574e59576",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "27600.361873331771459358",
+        "tokens": [
+            {
+                "address": "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+                "balance": "19847.016922316595631554",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xeaa1cba8cc3cf01a92e9e853e90277b5b8a23e07",
+                "balance": "7948.041216932120419956",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+            "0xeaa1cba8cc3cf01a92e9e853e90277b5b8a23e07"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1651267340",
+        "unitSeconds": "437694924",
+        "principalToken": "0xeaa1cba8cc3cf01a92e9e853e90277b5b8a23e07",
+        "baseToken": "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x62d3ceab68db0bf20f4c7f1438dbc8acec73f2370002000000000000000000aa",
+        "address": "0x62d3ceab68db0bf20f4c7f1438dbc8acec73f237",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0.000000000001",
+        "tokens": [
+            {
+                "address": "0x06325440d014e39736583c165c2963ba99faf14e",
+                "balance": "0.000000000000017804",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xeb1a6c6ea0cd20847150c27b5985fa198b2f90bd",
+                "balance": "0.00000000001404209",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x06325440d014e39736583c165c2963ba99faf14e",
+            "0xeb1a6c6ea0cd20847150c27b5985fa198b2f90bd"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5fa3ce1fb47bc8a29b5c02e2e7167799bbaf5f410002000000000000000000a7",
+        "address": "0x5fa3ce1fb47bc8a29b5c02e2e7167799bbaf5f41",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "3.62638731136091896",
+        "tokens": [
+            {
+                "address": "0x194ebd173f6cdace046c53eacce9b953f28411d1",
+                "balance": "0.362733748407268756",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x1ac5d65a987d448b0ecfe7e39017c3ec516d1d87",
+                "balance": "9.067784055512549134",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x194ebd173f6cdace046c53eacce9b953f28411d1",
+            "0x1ac5d65a987d448b0ecfe7e39017c3ec516d1d87"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5d254429194177220b6791f5bcdd09eff54273dd000200000000000000000162",
+        "address": "0x5d254429194177220b6791f5bcdd09eff54273dd",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe73b90231b9301a47556c246e7271769a30bddef",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xe73b90231b9301a47556c246e7271769a30bddef"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x5b1c06c4923dbba4b27cfa270ffb2e60aa28615900020000000000000000004a",
+        "address": "0x5b1c06c4923dbba4b27cfa270ffb2e60aa286159",
+        "poolType": "Weighted",
+        "swapFee": "0.0015",
+        "totalShares": "2423890.599645233291425148",
+        "tokens": [
+            {
+                "address": "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+                "balance": "783494.006113919127537271",
+                "decimals": 18,
+                "weight": "0.75",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x90b831fa3bebf58e9744a14d638e25b4ee06f9bc",
+                "balance": "4688989.274473964234415156",
+                "decimals": 18,
+                "weight": "0.25",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x68037790a0229e9ce6eaa8a99ea92964106c4703",
+            "0x90b831fa3bebf58e9744a14d638e25b4ee06f9bc"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x56f30398d13f111401d6e7ffe758254a0946687d000200000000000000000105",
+        "address": "0x56f30398d13f111401d6e7ffe758254a0946687d",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "2505683.837420829312832821",
+        "tokens": [
+            {
+                "address": "0x0740a6cfb9468b8b53070c0b327099293dccb82d",
+                "balance": "1817583.428723472666841193",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "711043.451746219331238938",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0740a6cfb9468b8b53070c0b327099293dccb82d",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1651264326",
+        "unitSeconds": "875389848",
+        "principalToken": "0x0740a6cfb9468b8b53070c0b327099293dccb82d",
+        "baseToken": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x544c823194218f0640dae8291c1f59752d25fae3000200000000000000000093",
+        "address": "0x544c823194218f0640dae8291c1f59752d25fae3",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "7.350891066527278413",
+        "tokens": [
+            {
+                "address": "0x06325440d014e39736583c165c2963ba99faf14e",
+                "balance": "0.902712444846507337",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x720465a4ae6547348056885060eeb51f9cadb571",
+                "balance": "6.492525185863803066",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x06325440d014e39736583c165c2963ba99faf14e",
+            "0x720465a4ae6547348056885060eeb51f9cadb571"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1643382514",
+        "unitSeconds": "583488042",
+        "principalToken": "0x720465a4ae6547348056885060eeb51f9cadb571",
+        "baseToken": "0x06325440d014e39736583c165c2963ba99faf14e",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4fd63966879300cafafbb35d157dc5229278ed230000000000000000000000e9",
+        "address": "0x4fd63966879300cafafbb35d157dc5229278ed23",
+        "poolType": "StablePhantom",
+        "swapFee": "0.00005",
+        "totalShares": "300",
+        "tokens": [
+            {
+                "address": "0x4fd63966879300cafafbb35d157dc5229278ed23",
+                "balance": "5192296858534527.628530496329220095",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x652d486b80c461c397b0d95612a404da936f3db3",
+                "balance": "100.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xa3823e50f20982656557a4a6a9c06ba5467ae908",
+                "balance": "100.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xe6bcc79f328eec93d4ec8f7ed35534d9ab549faa",
+                "balance": "100.0",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x4fd63966879300cafafbb35d157dc5229278ed23",
+            "0x652d486b80c461c397b0d95612a404da936f3db3",
+            "0xa3823e50f20982656557a4a6a9c06ba5467ae908",
+            "0xe6bcc79f328eec93d4ec8f7ed35534d9ab549faa"
+        ],
+        "totalWeight": "0",
+        "amp": "100.0",
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d000100000000000000000031",
+        "address": "0x4e7f40cd37cee710f5e87ad72959d30ef8a01a5d",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.3",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x111111111117dc0aa78b770fa6a738034120c302",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b175474e89094c44da98b954eedeac495271d0f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x8798249c2e607446efb7ad49ec89dd1865ff4272",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.1",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x0bc529c00c6401aef6d220be8c6ea1667f6ad93e",
+            "0x111111111117dc0aa78b770fa6a738034120c302",
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x6b175474e89094c44da98b954eedeac495271d0f",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x8798249c2e607446efb7ad49ec89dd1865ff4272",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4abb6fd289fa70056cfcb58cebab8689921eb9220002000000000000000000b6",
+        "address": "0x4abb6fd289fa70056cfcb58cebab8689921eb922",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "13.125267559402497669",
+        "tokens": [
+            {
+                "address": "0x939fd8bfcfed01ec51f86df105821e3c5dc53c1c",
+                "balance": "32.751596975321480891",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc4ad29ba4b3c580e6d59105fff484999997675ff",
+                "balance": "1.31610454687560243",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x939fd8bfcfed01ec51f86df105821e3c5dc53c1c",
+            "0xc4ad29ba4b3c580e6d59105fff484999997675ff"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x432eb5a7e69f0753298f111b0ce633642392560800020000000000000000010d",
+        "address": "0x432eb5a7e69f0753298f111b0ce6336423925608",
+        "poolType": "Weighted",
+        "swapFee": "0.025",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.5",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x43d4a3cd90ddd2f8f4f693170c9c8098163502ad",
+            "0xba100000625a3754423978a60c9317c58a424e3d"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4212be3c7b255ba4b29705573abd023cdce21542000200000000000000000092",
+        "address": "0x4212be3c7b255ba4b29705573abd023cdce21542",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "4.302818206888200667",
+        "tokens": [
+            {
+                "address": "0x06325440d014e39736583c165c2963ba99faf14e",
+                "balance": "0.135028749975512157",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xaf5d6d2e724f43769fa9e44284f0433a8f5be973",
+                "balance": "34.363640466904132932",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x06325440d014e39736583c165c2963ba99faf14e",
+            "0xaf5d6d2e724f43769fa9e44284f0433a8f5be973"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x4175462049be7be138f67f4468002193db35060d00020000000000000000018d",
+        "address": "0x4175462049be7be138f67f4468002193db35060d",
+        "poolType": "Weighted",
+        "swapFee": "0.01",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.2",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed1480d12be41d92f36f5f7bdd88212e381a3677",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.8",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+            "0xed1480d12be41d92f36f5f7bdd88212e381a3677"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3e63080d20122c67f5d810eef738cbfe6f84dcee000200000000000000000193",
+        "address": "0x3e63080d20122c67f5d810eef738cbfe6f84dcee",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x514910771af9ca656af840dff83e8264ecf986ca",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.02",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.98",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x514910771af9ca656af840dff83e8264ecf986ca",
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3b40d7d5ae25df2561944dd68b252016c4c7b2800001000000000000000000c2",
+        "address": "0x3b40d7d5ae25df2561944dd68b252016c4c7b280",
+        "poolType": "Investment",
+        "swapFee": "0.005",
+        "totalShares": "103.171853148125164988",
+        "tokens": [
+            {
+                "address": "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+                "balance": "36.050269456318687653",
+                "decimals": 18,
+                "weight": "0.250000000058207661",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+                "balance": "23.627706990187127172",
+                "decimals": 18,
+                "weight": "0.064900000129104592",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "1.330124773455702505",
+                "decimals": 18,
+                "weight": "0.182500000154250302",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+                "balance": "0.068281410993302501",
+                "decimals": 18,
+                "weight": "0.093200000024680049",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc00e94cb662c3520282e6f5717214004a7f26888",
+                "balance": "0.769032100064569429",
+                "decimals": 18,
+                "weight": "0.075200000096857548",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+                "balance": "14.201706236918875108",
+                "decimals": 18,
+                "weight": "0.059600000050757081",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                "balance": "647.579221082846204702",
+                "decimals": 18,
+                "weight": "0.206900000154715963",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+                "balance": "38.206368639288763092",
+                "decimals": 18,
+                "weight": "0.067700000029918738",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x1f9840a85d5af5bf1d1762f925bdaddc4201f984",
+            "0x6b3595068778dd592e39a122f4f5a5cf09c90fe2",
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0x9f8f72aa9304c8b593d555f12ef6589cc3a579a2",
+            "0xc00e94cb662c3520282e6f5717214004a7f26888",
+            "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f",
+            "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+            "0xd533a949740bb3306d119cc777fa900ba034cd52"
+        ],
+        "totalWeight": "1.000000000698491934",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x3a693eb97b500008d4bb6258906f7bbca1d09cc5000200000000000000000065",
+        "address": "0x3a693eb97b500008d4bb6258906f7bbca1d09cc5",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "0.352651250557163023",
+        "tokens": [
+            {
+                "address": "0x237535da7e2f0aba1b68262abcf7c4e60b42600c",
+                "balance": "0.328302006187054917",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf",
+                "balance": "0.026594335871212525",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x237535da7e2f0aba1b68262abcf7c4e60b42600c",
+            "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1628997564",
+        "unitSeconds": "194390824",
+        "principalToken": "0x237535da7e2f0aba1b68262abcf7c4e60b42600c",
+        "baseToken": "0xca3d75ac011bf5ad07a98d02f18225f9bd9a6bdf",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x2c2e3c226b8771adba45a7a689a10bdb7cc578cb0002000000000000000000a5",
+        "address": "0x2c2e3c226b8771adba45a7a689a10bdb7cc578cb",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x8c981f68015d8eb13883bfd25aaf4b7c05ec7df5",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+            "0x8c981f68015d8eb13883bfd25aaf4b7c05ec7df5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x22939e40cf467de8f5db4f05a4027e5d4c1c658c000200000000000000000059",
+        "address": "0x22939e40cf467de8f5db4f05a4027e5d4c1c658c",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "0.998196707955858196",
+        "tokens": [
+            {
+                "address": "0xd44bf95bf21c83b46049bf9e34633f3300b280f6",
+                "balance": "0.445793181825527137",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+                "balance": "0.552420338257799201",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xd44bf95bf21c83b46049bf9e34633f3300b280f6",
+            "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1625028466",
+        "unitSeconds": "631139040",
+        "principalToken": "0xd44bf95bf21c83b46049bf9e34633f3300b280f6",
+        "baseToken": "0xed279fdd11ca84beef15af5d39bb4d4bee23f0ca",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x1d310a6238e11c8be91d83193c88a99eb66279be0002000000000000000000a2",
+        "address": "0x1d310a6238e11c8be91d83193c88a99eb66279be",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "5175.056992685646437199",
+        "tokens": [
+            {
+                "address": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+                "balance": "592.79249482378313282",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x8c981f68015d8eb13883bfd25aaf4b7c05ec7df5",
+                "balance": "11448.305938306560881677",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+            "0x8c981f68015d8eb13883bfd25aaf4b7c05ec7df5"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x14792d3f6fcf2661795d1e08ef818bf612708bbf0002000000000000000000be",
+        "address": "0x14792d3f6fcf2661795d1e08ef818bf612708bbf",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "25861.15599737288357457",
+        "tokens": [
+            {
+                "address": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+                "balance": "9903.12225179094670231",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc63958d9d01efa6b8266b1df3862c6323cbdb52b",
+                "balance": "16346.950865067703074778",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+            "0xc63958d9d01efa6b8266b1df3862c6323cbdb52b"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1651247155",
+        "unitSeconds": "368585199",
+        "principalToken": "0xc63958d9d01efa6b8266b1df3862c6323cbdb52b",
+        "baseToken": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x11b94a947a9ca400c83105610335988deccd97d2000100000000000000000154",
+        "address": "0x11b94a947a9ca400c83105610335988deccd97d2",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+                "balance": "0.0",
+                "decimals": 6,
+                "weight": "0.02",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xae78736cd615f374d3085123a210448e74fc6393",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.74",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.185",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd533a949740bb3306d119cc777fa900ba034cd52",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.055",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
+            "0xae78736cd615f374d3085123a210448e74fc6393",
+            "0xae7ab96520de3a18e5e111b5eaab095312d7fe84",
+            "0xd533a949740bb3306d119cc777fa900ba034cd52"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x10f21c9bd8128a29aa785ab2de0d044dcdd794360002000000000000000000ce",
+        "address": "0x10f21c9bd8128a29aa785ab2de0d044dcdd79436",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "17135.084608917598480546",
+        "tokens": [
+            {
+                "address": "0x394442cd20208c9bfdc6535d5d89bb932a05ea87",
+                "balance": "57561.782616699956952216",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            },
+            {
+                "address": "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c",
+                "balance": "1275.596906676785651459",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x394442cd20208c9bfdc6535d5d89bb932a05ea87",
+            "0x43b4fdfd4ff969587185cdb6f0bd875c5fc83f8c"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x0b55c8d4f9d5dd4de88519a11ba84178f8b0c3c100010000000000000000018c",
+        "address": "0x0b55c8d4f9d5dd4de88519a11ba84178f8b0c3c1",
+        "poolType": "Weighted",
+        "swapFee": "0.0042",
+        "totalShares": "0",
+        "tokens": [
+            {
+                "address": "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba100000625a3754423978a60c9317c58a424e3d",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xba5bde662c17e2adff1075610382b9b691296350",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb",
+                "balance": "0.0",
+                "decimals": 18,
+                "weight": "0.125",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x7fc66500c84a76ad7e9c93437bfc5ac33e2ddae9",
+            "0xba100000625a3754423978a60c9317c58a424e3d",
+            "0xba5bde662c17e2adff1075610382b9b691296350",
+            "0xc18360217d8f7ab5e7c516566761ea12ce7f9d72",
+            "0xd33526068d116ce69f19a9ee46f0bd304f21a51f",
+            "0xde30da39c46104798bb5aa3fe8b9e0e1f348163f",
+            "0xf2051511b9b121394fa75b8f7d4e7424337af687",
+            "0xfb5453340c03db5ade474b27e68b6a9c6b2823eb"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x09b1b33bad0e87454ff05696b1151bfbd208a43f0002000000000000000000a6",
+        "address": "0x09b1b33bad0e87454ff05696b1151bfbd208a43f",
+        "poolType": "Element",
+        "swapFee": "0.1",
+        "totalShares": "118184.688021991594310881",
+        "tokens": [
+            {
+                "address": "0x418de6227499181b045cadf554030722e460881a",
+                "balance": "120324.035503090458119752",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            },
+            {
+                "address": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+                "balance": "499.641899032766098309",
+                "decimals": 18,
+                "weight": null,
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x418de6227499181b045cadf554030722e460881a",
+            "0x5a6a4d54456819380173272a5e8e9b9904bdf41b"
+        ],
+        "totalWeight": "0",
+        "amp": null,
+        "expiryTime": "1644601070",
+        "unitSeconds": "350282167",
+        "principalToken": "0x418de6227499181b045cadf554030722e460881a",
+        "baseToken": "0x5a6a4d54456819380173272a5e8e9b9904bdf41b",
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    },
+    {
+        "id": "0x062f38735aac32320db5e2dbbeb07968351d7c720002000000000000000000ac",
+        "address": "0x062f38735aac32320db5e2dbbeb07968351d7c72",
+        "poolType": "Weighted",
+        "swapFee": "0.003",
+        "totalShares": "15.576928239460363764",
+        "tokens": [
+            {
+                "address": "0x06325440d014e39736583c165c2963ba99faf14e",
+                "balance": "0.542686902183649369",
+                "decimals": 18,
+                "weight": "0.500000000000000001",
+                "priceRate": "1"
+            },
+            {
+                "address": "0xeb1a6c6ea0cd20847150c27b5985fa198b2f90bd",
+                "balance": "112.01793147158814308",
+                "decimals": 18,
+                "weight": "0.499999999999999999",
+                "priceRate": "1"
+            }
+        ],
+        "tokensList": [
+            "0x06325440d014e39736583c165c2963ba99faf14e",
+            "0xeb1a6c6ea0cd20847150c27b5985fa198b2f90bd"
+        ],
+        "totalWeight": "1",
+        "amp": null,
+        "expiryTime": null,
+        "unitSeconds": null,
+        "principalToken": null,
+        "baseToken": null,
+        "swapEnabled": true,
+        "wrappedIndex": 0,
+        "mainIndex": 0,
+        "lowerTarget": null,
+        "upperTarget": null
+    }
+]

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -469,9 +469,10 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/sor@/Users/jg/Documents/balancer-sor/balancer-labs-sor-v4.0.0-beta.8.tgz":
-  version "4.0.0-beta.3"
-  resolved "/Users/jg/Documents/balancer-sor/balancer-labs-sor-v4.0.0-beta.8.tgz#e8254ee8273c72e9142fcd758637b2340e4f0177"
+"@balancer-labs/sor@^4.0.0-beta.5":
+  version "4.0.0-beta.5"
+  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-4.0.0-beta.5.tgz#a2ea6ffcd7ca918449f3d4c91f2799191107ffd5"
+  integrity sha512-z4YYSXP6y/gisAQqVeQVkjg/lqGF++GTycsWzr2cu5xy0qy/epDyy6X+46vQf4RW2j/IIOCNeqD/iT5v2V3Ehg==
   dependencies:
     isomorphic-fetch "^2.2.1"
 

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -469,10 +469,9 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/sor@^4.0.0-beta.2":
-  version "4.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-4.0.0-beta.2.tgz#17ee901c7434f9a5702653488b1a3ec6e1f926f1"
-  integrity sha512-ylDxsMDKpoynOQIH4PhucYc7bkXddjL6GRFCF2BwnQ4Yoy7vBOT7S0zJvIkKuUG6MSUdoTBaAtWckxXBJiNxyA==
+"@balancer-labs/sor@/Users/jg/Documents/balancer-sor/balancer-labs-sor-v4.0.0-beta.8.tgz":
+  version "4.0.0-beta.3"
+  resolved "/Users/jg/Documents/balancer-sor/balancer-labs-sor-v4.0.0-beta.8.tgz#e8254ee8273c72e9142fcd758637b2340e4f0177"
   dependencies:
     isomorphic-fetch "^2.2.1"
 


### PR DESCRIPTION
Add support to make it easy for a user to:
- Get SP for a token pair:
    - for a specific pool.
- Get Spot Price (SP) for a token pair:
    - considering all paths.
    - This is the SP of the most liquid path for pair as found by SOR.
 
 Added snapshot of mainnet pool state in json format to enable testing of path finding.
 TO DO 
 - SOR package needs updated with some function exposed.
 - Update readme.
