### PR TITLE
fix: exclude spec files at build

### DIFF
--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -20,7 +20,7 @@
         "dist/"
     ],
     "scripts": {
-        "build": "rollup -c",
+        "build": "rimraf dist && rollup -c",
         "dev": "rollup -c -w",
         "test": "ts-mocha --paths --recursive -p tsconfig.testing.json 'src/**/*.spec.ts'",
         "test:only": "ts-mocha --paths --recursive -p tsconfig.testing.json",
@@ -71,6 +71,7 @@
         "hardhat": "^2.9.3",
         "mocha": "^8.2.1",
         "prettier": "^2.1.2",
+        "rimraf": "^3.0.2",
         "rollup": "^2.52.8",
         "rollup-plugin-dts": "^3.0.2",
         "tiny-invariant": "^1.1.0",

--- a/balancer-js/rollup.config.ts
+++ b/balancer-js/rollup.config.ts
@@ -38,12 +38,14 @@ export default [
             { file: pkg.main, format: 'cjs', sourcemap: true },
             { file: pkg.module, format: 'es', sourcemap: true },
         ],
-        plugins: [nodeResolve(), json(), commonjs(), typescript()],
+        plugins: [nodeResolve(), json(), commonjs(), typescript({
+            exclude: ['node_modules', '**/*.spec.ts'],
+        })],
         external,
     },
     {
         input: 'src/index.ts',
         output: [{ file: 'dist/index.d.ts', format: 'es' }],
-        plugins: [dts(), typescript()],
+        plugins: [dts(), typescript({ exclude: ['node_modules', '**/*.spec.ts'] })],
     },
 ];

--- a/balancer-js/tsconfig.json
+++ b/balancer-js/tsconfig.json
@@ -18,6 +18,6 @@
         }
     },
     "include": ["./src", "src/abi/*.json"],
-    "exclude": ["node_modules", "**/*.spec.ts"],
+    "exclude": ["node_modules"],
     "files": ["hardhat.config.js"]
 }


### PR DESCRIPTION
TS exclude option can be passed directly in rollup config.
Additionally added rimraf package which deleting all files in dist folder before building.