### PR TITLE
fix: add missing goerli with utf8 spelling

### DIFF
--- a/balancer-js/src/lib/constants/network.ts
+++ b/balancer-js/src/lib/constants/network.ts
@@ -3,6 +3,7 @@ export enum Network {
   ROPSTEN = 3,
   RINKEBY = 4,
   GOERLI = 5,
+  GÖRLI = 5,
   KOVAN = 42,
   POLYGON = 137,
   ARBITRUM = 42161,


### PR DESCRIPTION
Frontend is referencing Network.GÖRLI, but SDK was specifying is with a GOERLI spelling. This PR is adding UTF8 spelling as well.