### PR TITLE
Generalised joins non leaf input

### DIFF
--- a/balancer-js/src/balancerErrors.ts
+++ b/balancer-js/src/balancerErrors.ts
@@ -9,6 +9,7 @@ export enum BalancerErrorCode {
   NO_POOL_DATA = 'NO_POOL_DATA',
   INPUT_OUT_OF_BOUNDS = 'INPUT_OUT_OF_BOUNDS',
   INPUT_LENGTH_MISMATCH = 'INPUT_LENGTH_MISMATCH',
+  INPUT_TOKEN_INVALID = 'INPUT_TOKEN_INVALID',
   TOKEN_MISMATCH = 'TOKEN_MISMATCH',
   MISSING_TOKENS = 'MISSING_TOKENS',
   MISSING_AMP = 'MISSING_AMP',
@@ -45,6 +46,8 @@ export class BalancerError extends Error {
         return 'input out of bounds';
       case BalancerErrorCode.INPUT_LENGTH_MISMATCH:
         return 'input length mismatch';
+      case BalancerErrorCode.INPUT_TOKEN_INVALID:
+        return 'input token invalid';
       case BalancerErrorCode.TOKEN_MISMATCH:
         return 'token mismatch';
       case BalancerErrorCode.MISSING_DECIMALS:

--- a/balancer-js/src/modules/joins/graph.module.spec.ts
+++ b/balancer-js/src/modules/joins/graph.module.spec.ts
@@ -260,7 +260,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(rootNode);
+        const orderedNodes = PoolGraph.orderByBfs(rootNode);
         expect(orderedNodes.length).to.eq(3);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('WrappedToken');
@@ -287,7 +287,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(rootNode);
+        const orderedNodes = PoolGraph.orderByBfs(rootNode);
         expect(orderedNodes.length).to.eq(2);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('AaveLinear');
@@ -372,7 +372,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        const orderedNodes = PoolGraph.orderByBfs(boostedNode);
         expect(orderedNodes.length).to.eq(10);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('Input');
@@ -407,7 +407,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        const orderedNodes = PoolGraph.orderByBfs(boostedNode);
         expect(orderedNodes.length).to.eq(7);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('Input');
@@ -507,7 +507,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        const orderedNodes = PoolGraph.orderByBfs(boostedNode);
         expect(orderedNodes.length).to.eq(14);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('Input');
@@ -539,7 +539,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        const orderedNodes = PoolGraph.orderByBfs(boostedNode);
         expect(orderedNodes.length).to.eq(10);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('Input');
@@ -561,14 +561,14 @@ describe('Graph', () => {
           rootPool.id,
           false
         );
-        orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        orderedNodes = PoolGraph.orderByBfs(boostedNode);
       });
 
       it('should throw when token not in tree', () => {
         const inputToken = ADDRESSES[Network.MAINNET].BAL.address;
         let reason = '';
         try {
-          poolsGraph.getNodesToRoot(orderedNodes, inputToken, 0);
+          PoolGraph.getNodesToRoot(orderedNodes, inputToken, 0);
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
           reason = err.message;
@@ -579,7 +579,7 @@ describe('Graph', () => {
         const inputToken = rootPool.address;
         let reason = '';
         try {
-          poolsGraph.getNodesToRoot(orderedNodes, inputToken, 0);
+          PoolGraph.getNodesToRoot(orderedNodes, inputToken, 0);
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
         } catch (err: any) {
           reason = err.message;
@@ -588,7 +588,7 @@ describe('Graph', () => {
       });
       it('leaf input', () => {
         const inputToken = ADDRESSES[Network.MAINNET].DAI.address;
-        const nodes = poolsGraph.getNodesToRoot(orderedNodes, inputToken, 0);
+        const nodes = PoolGraph.getNodesToRoot(orderedNodes, inputToken, 0);
         expect(nodes.length).to.eq(4);
         expect(nodes[0].action).to.eq('input');
         expect(nodes[0].address).to.eq(inputToken);
@@ -599,7 +599,7 @@ describe('Graph', () => {
       });
       it('child boosted bpt input', () => {
         const inputToken = boostedMetaInfo.childBoostedInfo.rootPool.address;
-        const nodes = poolsGraph.getNodesToRoot(orderedNodes, inputToken, 0);
+        const nodes = PoolGraph.getNodesToRoot(orderedNodes, inputToken, 0);
         expect(nodes.length).to.eq(2);
         expect(nodes[0].action).to.eq('input');
         expect(nodes[0].address).to.eq(inputToken);
@@ -715,7 +715,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        const orderedNodes = PoolGraph.orderByBfs(boostedNode);
         expect(orderedNodes.length).to.eq(21);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('Input');
@@ -754,7 +754,7 @@ describe('Graph', () => {
       });
 
       it('should sort in breadth first order', async () => {
-        const orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        const orderedNodes = PoolGraph.orderByBfs(boostedNode);
         expect(orderedNodes.length).to.eq(15);
         expect(orderedNodes[0].type).to.eq('Input');
         expect(orderedNodes[1].type).to.eq('Input');
@@ -780,11 +780,11 @@ describe('Graph', () => {
           boostedPool.id,
           false
         );
-        orderedNodes = poolsGraph.orderByBfs(boostedNode);
+        orderedNodes = PoolGraph.orderByBfs(boostedNode);
       });
       it('leaf input', () => {
         const inputToken = ADDRESSES[Network.MAINNET].DAI.address;
-        const nodes = poolsGraph.getNodesToRoot(orderedNodes, inputToken, 0);
+        const nodes = PoolGraph.getNodesToRoot(orderedNodes, inputToken, 0);
         expect(nodes.length).to.eq(4);
         expect(nodes[0].action).to.eq('input');
         expect(nodes[0].address).to.eq(inputToken);
@@ -795,7 +795,7 @@ describe('Graph', () => {
       });
       it('child boosted bpt input', () => {
         const inputToken = boostedMetaBigInfo.childPools[0].address;
-        const nodes = poolsGraph.getNodesToRoot(orderedNodes, inputToken, 0);
+        const nodes = PoolGraph.getNodesToRoot(orderedNodes, inputToken, 0);
         expect(nodes.length).to.eq(2);
         expect(nodes[0].action).to.eq('input');
         expect(nodes[0].address).to.eq(inputToken);

--- a/balancer-js/src/modules/joins/joins.module.spec.ts
+++ b/balancer-js/src/modules/joins/joins.module.spec.ts
@@ -4,6 +4,7 @@ import {
   BoostedParams,
   LinearParams,
   BoostedMetaBigParams,
+  BoostedMetaBigInfo,
 } from '@/test/factories/pools';
 import { StaticPoolRepository } from '../data';
 import { Pool } from '@/types';
@@ -11,6 +12,7 @@ import { Join } from './joins.module';
 import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { Network } from '@/lib/constants/network';
 import { formatAddress } from '@/test/lib/utils';
+import { ADDRESSES } from '@/test/lib/constants';
 
 describe('Generalised Joins', () => {
   context('Boosted', () => {
@@ -246,7 +248,7 @@ describe('Generalised Joins', () => {
       });
 
       it('single linear token', async () => {
-        const inputTokens = ['address_STABLE'];
+        const inputTokens = [formatAddress('address_STABLE')];
         const inputAmounts = ['1000000000000000000'];
         const root = await joinModule.joinPool(
           rootPool.id,
@@ -298,7 +300,7 @@ describe('Generalised Joins', () => {
       });
 
       it('single linear token', async () => {
-        const inputTokens = ['address_STABLE'];
+        const inputTokens = [formatAddress('address_STABLE')];
         const inputAmounts = ['1000000000000000000'];
         const root = await joinModule.joinPool(
           rootPool.id,
@@ -323,6 +325,38 @@ describe('Generalised Joins', () => {
         );
       });
     });
+
+    context('bpt input', () => {
+      const isWrapped = false;
+      it('only bpt in', async () => {
+        const inputTokens = ['0x616464726573732d6368696c6400000000000000'];
+        const inputAmounts = ['1000000000000000000'];
+        const root = await joinModule.joinPool(
+          rootPool.id,
+          '7777777',
+          inputTokens,
+          inputAmounts,
+          userAddress,
+          isWrapped
+        );
+      });
+
+      it('bpt and leaf', async () => {
+        const inputTokens = [
+          '0x616464726573732d6368696c6400000000000000',
+          ADDRESSES[Network.MAINNET].DAI.address,
+        ];
+        const inputAmounts = ['1000000000000000000', '1000000000000000000'];
+        const root = await joinModule.joinPool(
+          rootPool.id,
+          '7777777',
+          inputTokens,
+          inputAmounts,
+          userAddress,
+          isWrapped
+        );
+      });
+    });
   });
 
   // TO DO - Add boostedMetaBig with different leaf tokens
@@ -331,6 +365,7 @@ describe('Generalised Joins', () => {
     let joinModule: Join;
     let rootPool: SubgraphPoolBase;
     let userAddress: string;
+    let boostedMetaBigInfo: BoostedMetaBigInfo;
     before(() => {
       userAddress = formatAddress('testAccount');
       // The boostedMetaBig will have a phantomStable with two boosted.
@@ -406,7 +441,7 @@ describe('Generalised Joins', () => {
         childPools: [childBoosted1, childBoosted2],
       };
 
-      const boostedMetaBigInfo = factories.boostedMetaBigPool
+      boostedMetaBigInfo = factories.boostedMetaBigPool
         .transient(parentPool)
         .build();
       rootPool = boostedMetaBigInfo.rootPool;
@@ -474,6 +509,55 @@ describe('Generalised Joins', () => {
       it('single boosted leaf token', async () => {
         const inputTokens = ['0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48'];
         const inputAmounts = ['1000000'];
+        const root = await joinModule.joinPool(
+          rootPool.id,
+          '7777777',
+          inputTokens,
+          inputAmounts,
+          userAddress,
+          isWrapped
+        );
+      });
+    });
+    context('bpt input', () => {
+      const isWrapped = false;
+      it('single bpt in', async () => {
+        const inputTokens = [
+          boostedMetaBigInfo.childPoolsInfo[0].rootPool.address,
+        ];
+        const inputAmounts = ['1000000000000000000'];
+        const root = await joinModule.joinPool(
+          rootPool.id,
+          '7777777',
+          inputTokens,
+          inputAmounts,
+          userAddress,
+          isWrapped
+        );
+      });
+
+      it('two bpt in', async () => {
+        const inputTokens = [
+          boostedMetaBigInfo.childPoolsInfo[0].rootPool.address,
+          boostedMetaBigInfo.childPoolsInfo[1].rootPool.address,
+        ];
+        const inputAmounts = ['1000000000000000000', '2000000000000000000'];
+        const root = await joinModule.joinPool(
+          rootPool.id,
+          '7777777',
+          inputTokens,
+          inputAmounts,
+          userAddress,
+          isWrapped
+        );
+      });
+
+      it('bpt and leaf', async () => {
+        const inputTokens = [
+          boostedMetaBigInfo.childPools[0].address,
+          ADDRESSES[Network.MAINNET].DAI.address,
+        ];
+        const inputAmounts = ['1000000000000000000', '1000000000000000000'];
         const root = await joinModule.joinPool(
           rootPool.id,
           '7777777',


### PR DESCRIPTION
Adds method to handle non-leaf token joins.
- First we create the calls for leaf tokens
- Then for each non-leaf token we find the action path from the input node to the root by traversing up graph
- We create the calls for this path and add it as a separate chain