### PR TITLE
Generalised join relayerv4

### DIFF
--- a/balancer-js/hardhat.config.js
+++ b/balancer-js/hardhat.config.js
@@ -6,7 +6,7 @@ require('@nomiclabs/hardhat-ethers');
 module.exports = {
   networks: {
     hardhat: {
-      chainId: 1,
+      chainId: 5,
     },
   },
 };

--- a/balancer-js/src/lib/abi/BatchRelayerLibrary.json
+++ b/balancer-js/src/lib/abi/BatchRelayerLibrary.json
@@ -489,6 +489,25 @@
   {
     "inputs": [
       {
+        "internalType": "uint256",
+        "name": "ref",
+        "type": "uint256"
+      }
+    ],
+    "name": "peekChainedReferenceValue",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "value",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "address",
         "name": "relayer",
         "type": "address"

--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -173,7 +173,7 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       contracts: {
         vault: '0xBA12222222228d8Ba445958a75a0704d566BF2C8',
         multicall: '0x77dCa2C955b15e9dE4dbBCf1246B4B85b651e50e',
-        relayer: '0x7b9B6f094DC2Bd1c12024b0D9CC63d6993Be1888',
+        relayer: '0x4B1635c7D3D1FC353298f92083e82dF69e1E9158',
         gaugeController: '0xBB1CE49b16d55A1f2c6e88102f32144C7334B116',
         feeDistributor: '',
       },

--- a/balancer-js/src/modules/joins/joins.module.integration.spec.ts
+++ b/balancer-js/src/modules/joins/joins.module.integration.spec.ts
@@ -21,6 +21,13 @@ import { ADDRESSES } from '@/test/lib/constants';
 // const poolId =
 //   '0x13acd41c585d7ebb4a9460f7c8f50be60dc080cd00000000000000000000005f';
 // const blockNumber = 7452900;
+const network = Network.GOERLI;
+const blockNumber = 7577109;
+const subgraph = `https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-goerli-v2-beta`;
+const bbausd2id =
+  '0x3d5981bdd8d3e49eb7bbdc1d2b156a3ee019c18e0000000000000000000001a7';
+const bbausd2address = '0x3d5981bdd8d3e49eb7bbdc1d2b156a3ee019c18e';
+const bbadai = '0x594920068382f64e4bc06879679bd474118b97b1';
 
 /*
  * Testing on MAINNET
@@ -29,8 +36,13 @@ import { ADDRESSES } from '@/test/lib/constants';
  * - Run node on terminal: yarn run node
  * - Uncomment section below:
  */
-const network = Network.MAINNET;
-const blockNumber = 15495943;
+// const network = Network.MAINNET;
+// const blockNumber = 15519886;
+// const subgraph = `https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2-beta`;
+// const bbausd2id =
+//   '0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d';
+// const bbausd2address = '0xa13a9247ea42d743238089903570127dda72fe44';
+// const bbadai = '0xae37d54ae477268b9997d4161b96b8200755935c';
 
 dotenv.config();
 
@@ -42,7 +54,7 @@ const rpcUrl = 'http://127.0.0.1:8545';
 const sdk = new BalancerSDK({
   network,
   rpcUrl,
-  customSubgraphUrl: `https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2-beta`,
+  customSubgraphUrl: subgraph,
 });
 const { pools } = sdk;
 const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
@@ -54,8 +66,8 @@ const { contracts, contractAddresses } = new Contracts(
 const relayer = contractAddresses.relayer as string;
 const addresses = ADDRESSES[network];
 const fromPool = {
-  id: '0xa13a9247ea42d743238089903570127dda72fe4400000000000000000000035d', // bbausd2
-  address: '0xa13a9247ea42d743238089903570127dda72fe44',
+  id: bbausd2id,
+  address: bbausd2address,
 };
 const mainTokens = [addresses.DAI.address, addresses.USDC.address];
 // joins with wrapping require token approvals. These are taken care of as part of fork setup when wrappedTokens passed in.
@@ -64,7 +76,7 @@ const wrappedTokensIn = [
   addresses.waDAI.address,
   addresses.waUSDC.address,
 ];
-const linearPoolTokens = ['0xae37d54ae477268b9997d4161b96b8200755935c'];
+const linearPoolTokens = [bbadai];
 const slots = [addresses.DAI.slot, addresses.USDC.slot];
 const wrappedSlots = [
   addresses.waUSDT.slot,

--- a/balancer-js/src/modules/pools/index.ts
+++ b/balancer-js/src/modules/pools/index.ts
@@ -13,6 +13,7 @@ import { PoolTypeConcerns } from './pool-type-concerns';
 import { PoolApr } from './apr/apr';
 import { Liquidity } from '../liquidity/liquidity.module';
 import { Join } from '../joins/joins.module';
+import { JsonRpcSigner } from '@ethersproject/providers';
 
 /**
  * Controller / use-case layer for interacting with pools data.
@@ -87,6 +88,7 @@ export class Pools implements Findable<PoolWithMethods> {
     userAddress: string,
     wrapMainTokens: boolean,
     slippage: string,
+    signer: JsonRpcSigner,
     authorisation?: string
   ): Promise<{
     to: string;
@@ -100,6 +102,7 @@ export class Pools implements Findable<PoolWithMethods> {
       userAddress,
       wrapMainTokens,
       slippage,
+      signer,
       authorisation
     );
   }

--- a/balancer-js/src/test/lib/constants.ts
+++ b/balancer-js/src/test/lib/constants.ts
@@ -309,19 +309,19 @@ export const ADDRESSES = {
   },
   [Network.GOERLI]: {
     USDC: {
-      address: '0xe0c9275e44ea80ef17579d33c55136b7da269aeb',
+      address: '0xdabd33683bafdd448968ab6d6f47c3535c64bf0c',
       decimals: 6,
       symbol: 'USDC',
       slot: 0,
     },
     USDT: {
-      address: '0x1f1f156e0317167c11aa412e3d1435ea29dc3cce',
+      address: '0x14468fd5e1de5a5a4882fa5f4e2217c5a8ddcadb',
       decimals: 6,
       symbol: 'USDT',
       slot: 0,
     },
     DAI: {
-      address: '0x8c9e6c40d3402480ace624730524facc5482798c',
+      address: '0xb8096bc53c3ce4c11ebb0069da0341d75264b104',
       decimals: 18,
       symbol: 'DAI',
       slot: 0,
@@ -330,6 +330,24 @@ export const ADDRESSES = {
       address: '0x13acd41c585d7ebb4a9460f7c8f50be60dc080cd',
       decimals: 18,
       symbol: 'bbausd',
+    },
+    waDAI: {
+      address: '0x0b61329839d2ebea96e21f45d4b065dbf38a7af6',
+      decimals: 18,
+      symbol: 'waDAI',
+      slot: 52,
+    },
+    waUSDC: {
+      address: '0xb8b3c69687ac048f607d75d89145bc82232098ca',
+      decimals: 6,
+      symbol: 'waUSDC',
+      slot: 52,
+    },
+    waUSDT: {
+      address: '0x014c0b2b8c4ed33231f9b33aca21735c8f71bbfb',
+      decimals: 6,
+      symbol: 'waUSDT',
+      slot: 52,
     },
   },
 };


### PR DESCRIPTION
- ! Runs tests on Goerli fork !
- Run `yarn test:only ./src/modules/joins/joins.module.integration.spec.ts` to see result
- Adds BatchRelayer V4
- Fixes encoding issue in joinPool
- Adds functionality to peek outputRefrences from Relayer
- Creates one set of calls with peek additions.
- static calls and decodes to get peek values (for any node ending in root pool)
- Used to set minAmountOut value for final join amount
- Note - Current RelayerV4 on Goerli is incorrectly handling readonly values. This works for now but will likely need updated when relayer is fixed.