### PR TITLE
deducting protocol cut on yield tokens

### DIFF
--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -13,6 +13,8 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         lidoRelayer: '0xdcdbf71A870cc60C6F9B621E28a7D3Ffd6Dd4965',
         gaugeController: '0xc128468b7ce63ea702c1f104d55a2566b13d3abd',
         feeDistributor: '0xD3cf852898b21fc233251427c2DC93d3d604F3BB',
+        protocolFeePercentagesProvider:
+          '0x97207B095e4D5C9a6e4cfbfcd2C3358E03B90c4A',
       },
       tokens: {
         wrappedNativeAsset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',

--- a/balancer-js/src/modules/data/index.ts
+++ b/balancer-js/src/modules/data/index.ts
@@ -6,6 +6,7 @@ export * from './token';
 export * from './token-prices';
 export * from './fee-distributor/repository';
 export * from './fee-collector/repository';
+export * from './protocol-fees/provider';
 export * from './token-yields/repository';
 export * from './block-number';
 
@@ -18,6 +19,7 @@ import { LiquidityGaugeSubgraphRPCProvider } from './liquidity-gauges/provider';
 import { FeeDistributorRepository } from './fee-distributor/repository';
 import { FeeCollectorRepository } from './fee-collector/repository';
 import { TokenYieldsRepository } from './token-yields/repository';
+import { ProtocolFeesProvider } from './protocol-fees/provider';
 import { Provider } from '@ethersproject/providers';
 
 // initialCoingeckoList are used to get the initial token list for coingecko
@@ -32,6 +34,7 @@ export class Data implements BalancerDataRepositories {
   liquidityGauges;
   feeDistributor;
   feeCollector;
+  protocolFees;
   tokenYields;
   blockNumbers;
 
@@ -102,6 +105,14 @@ export class Data implements BalancerDataRepositories {
       networkConfig.addresses.contracts.vault,
       provider
     );
+
+    if (networkConfig.addresses.contracts.protocolFeePercentagesProvider) {
+      this.protocolFees = new ProtocolFeesProvider(
+        networkConfig.addresses.contracts.multicall,
+        networkConfig.addresses.contracts.protocolFeePercentagesProvider,
+        provider
+      );
+    }
 
     this.tokenYields = new TokenYieldsRepository();
   }

--- a/balancer-js/src/modules/data/protocol-fees/provider.ts
+++ b/balancer-js/src/modules/data/protocol-fees/provider.ts
@@ -1,0 +1,68 @@
+// 0x97207B095e4D5C9a6e4cfbfcd2C3358E03B90c4A
+
+import { Interface } from '@ethersproject/abi';
+import { Provider } from '@ethersproject/providers';
+import { Contract } from '@ethersproject/contracts';
+import { formatUnits } from '@ethersproject/units';
+import { Multicall } from '@/modules/contracts/multicall';
+
+const iProtocolFeePercentagesProvider = new Interface([
+  'function getSwapFeePercentage() view returns (uint)',
+]);
+
+export interface ProtocolFees {
+  swapFee: number;
+  yieldFee: number;
+}
+
+// Using singleton here, so subsequent calls will return the same promise
+let feesPromise: Promise<ProtocolFees>;
+
+export class ProtocolFeesProvider {
+  multicall: Contract;
+  protocolFees?: ProtocolFees;
+
+  constructor(
+    multicallAddress: string,
+    private protocolFeePercentagesProviderAddress: string,
+    provider: Provider
+  ) {
+    this.multicall = Multicall(multicallAddress, provider);
+  }
+
+  private async fetch(): Promise<ProtocolFees> {
+    const payload = [
+      [
+        this.protocolFeePercentagesProviderAddress,
+        iProtocolFeePercentagesProvider.encodeFunctionData(
+          'getFeeTypePercentage',
+          [0]
+        ),
+      ],
+      [
+        this.protocolFeePercentagesProviderAddress,
+        iProtocolFeePercentagesProvider.encodeFunctionData(
+          'getFeeTypePercentage',
+          [2]
+        ),
+      ],
+    ];
+    const [, res] = await this.multicall.aggregate(payload);
+
+    const fees = {
+      swapFee: parseFloat(formatUnits(res[0], 18)),
+      yieldFee: parseFloat(formatUnits(res[2], 18)),
+    };
+
+    return fees;
+  }
+
+  async getFees(): Promise<ProtocolFees> {
+    if (!feesPromise) {
+      feesPromise = this.fetch();
+    }
+    this.protocolFees = await feesPromise;
+
+    return this.protocolFees;
+  }
+}

--- a/balancer-js/src/modules/data/types.ts
+++ b/balancer-js/src/modules/data/types.ts
@@ -1,6 +1,7 @@
 export { LiquidityGauge } from './liquidity-gauges/provider';
 export { PoolAttribute } from './pool/types';
 export { TokenAttribute } from './token/types';
+export { ProtocolFees } from './protocol-fees/provider';
 
 export interface Findable<T, P = string> {
   find: (id: string) => Promise<T | undefined>;

--- a/balancer-js/src/modules/pools/apr/apr.ts
+++ b/balancer-js/src/modules/pools/apr/apr.ts
@@ -9,7 +9,11 @@ import type {
   TokenAttribute,
   LiquidityGauge,
 } from '@/types';
-import { BaseFeeDistributor, RewardData } from '@/modules/data';
+import {
+  BaseFeeDistributor,
+  ProtocolFeesProvider,
+  RewardData,
+} from '@/modules/data';
 import { ProtocolRevenue } from './protocol-revenue';
 import { Liquidity } from '@/modules/liquidity/liquidity.module';
 import { identity, zipObject, pickBy } from 'lodash';
@@ -54,7 +58,8 @@ export class PoolApr {
     private feeCollector: Findable<number>,
     private yesterdaysPools?: Findable<Pool, PoolAttribute>,
     private liquidityGauges?: Findable<LiquidityGauge>,
-    private feeDistributor?: BaseFeeDistributor
+    private feeDistributor?: BaseFeeDistributor,
+    private protocolFees?: ProtocolFeesProvider
   ) {}
 
   /**
@@ -106,7 +111,17 @@ export class PoolApr {
       const tokenYield = await this.tokenYields.find(token.address);
 
       if (tokenYield) {
-        apr = tokenYield;
+        if (pool.poolType === 'MetaStable') {
+          apr = tokenYield * (1 - (await this.protocolSwapFeePercentage()));
+        } else if (pool.poolType === 'ComposableStable') {
+          // TODO: add if(token.isTokenExemptFromYieldProtocolFee) once supported by subgraph
+          // apr = tokenYield;
+
+          const fees = await this.protocolFeesPercentage();
+          apr = tokenYield * (1 - fees.yieldFee);
+        } else {
+          apr = tokenYield;
+        }
       } else {
         // Handle subpool APRs with recursive call to get the subPool APR
         const subPool = await this.pools.findBy('address', token.address);
@@ -381,6 +396,17 @@ export class PoolApr {
     const fee = await this.feeCollector.find('');
 
     return fee ? fee : 0;
+  }
+
+  private async protocolFeesPercentage() {
+    if (this.protocolFees) {
+      return await this.protocolFees.getFees();
+    }
+
+    return {
+      swapFee: 0,
+      yieldFee: 0,
+    };
   }
 
   private async rewardTokenApr(tokenAddress: string, rewardData: RewardData) {

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -13,7 +13,7 @@ import type {
   PoolAttribute,
   TokenAttribute,
 } from '@/modules/data/types';
-import type { BaseFeeDistributor } from './modules/data';
+import type { BaseFeeDistributor, ProtocolFeesProvider } from './modules/data';
 import type { GraphQLArgs } from './lib/graphql';
 
 import type { AprBreakdown } from '@/modules/pools/apr/apr';
@@ -50,6 +50,7 @@ export interface ContractAddresses {
   lidoRelayer?: string;
   gaugeController?: string;
   feeDistributor?: string;
+  protocolFeePercentagesProvider?: string;
 }
 
 export interface BalancerNetworkConfig {
@@ -84,6 +85,7 @@ export interface BalancerDataRepositories {
   liquidityGauges?: Findable<LiquidityGauge>;
   feeDistributor?: BaseFeeDistributor;
   feeCollector: Findable<number>;
+  protocolFees?: ProtocolFeesProvider;
   tokenYields: Findable<number>;
 }
 


### PR DESCRIPTION
For MetaStable pools, the protocol applies the SwapFeePercentage to the yield.
For ComposablePools and the WeightedPoolsV2, the protocol's cut is stored in the pool itself accessible via ProtocolFeePercentagesProvider