### PR TITLE
Add attributes to SubgraphPoolToken graphql type

### DIFF
--- a/balancer-js/src/modules/subgraph/balancer-v2/Pools.graphql
+++ b/balancer-js/src/modules/subgraph/balancer-v2/Pools.graphql
@@ -163,6 +163,11 @@ fragment SubgraphPoolToken on PoolToken {
     managedBalance
     weight
     priceRate
+    token {
+        pool {
+            poolType
+        }
+    }
 }
 
 query PoolHistoricalLiquidities(


### PR DESCRIPTION
Adds token > pool > poolType attribute to the SubgraphPoolToken graphql type. These attributes make it trivial to check if a pool is deeply nested, i.e. has pool tokens that are pools themselves.