### PR TITLE
Use lowercase addresses when finding tokens. Scale rewardTokens correctly.

### DIFF
--- a/balancer-js/src/modules/data/token-prices/coingecko.spec.ts
+++ b/balancer-js/src/modules/data/token-prices/coingecko.spec.ts
@@ -41,8 +41,9 @@ describe('coingecko repository', () => {
   });
 
   it('finds prices', async () => {
-    const [price1, price2, price3, price4, price5] = await Promise.all([
+    const [price1, price2, price3, price4, price5, price6] = await Promise.all([
       repository.find(addresses[0]),
+      repository.find(addresses[0].toUpperCase()),
       repository.find(addresses[1]),
       repository.find(addresses[2]),
       repository.find(addresses[3]),
@@ -51,7 +52,8 @@ describe('coingecko repository', () => {
     expect(price1?.usd).to.be.gt(0);
     expect(price2?.usd).to.be.gt(0);
     expect(price3?.usd).to.be.gt(0);
-    expect(price4?.usd).to.be.undefined;
+    expect(price4?.usd).to.be.gt(0);
     expect(price5?.usd).to.be.undefined;
+    expect(price6?.usd).to.be.undefined;
   });
 });

--- a/balancer-js/src/modules/data/token-prices/index.ts
+++ b/balancer-js/src/modules/data/token-prices/index.ts
@@ -1,3 +1,2 @@
-export * from './types';
 export * from './static';
 export * from './coingecko';

--- a/balancer-js/src/modules/data/token-prices/static.spec.ts
+++ b/balancer-js/src/modules/data/token-prices/static.spec.ts
@@ -1,0 +1,38 @@
+import { TokenPrices } from '@/types';
+import { expect } from 'chai';
+import { StaticTokenPriceProvider } from './static';
+
+const TOKENS = {
+  BAL: '0x9a71012B13CA4d3D0Cdc72A177DF3ef03b0E76A3',
+  WMATIC: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+};
+
+let staticTokenPriceProvider: StaticTokenPriceProvider;
+
+describe('static token prices repository', () => {
+  it('Should store token addresses as lower case internally', async () => {
+    const tokenPrices: TokenPrices = {
+      [TOKENS.BAL]: {
+        usd: '10',
+      },
+    };
+    staticTokenPriceProvider = new StaticTokenPriceProvider(tokenPrices);
+    expect(
+      await staticTokenPriceProvider.find(TOKENS.BAL.toLowerCase())
+    ).to.deep.eq({
+      usd: '10',
+    });
+  });
+
+  it('When finding by upper case address it converts to lower case', async () => {
+    const tokenPrices: TokenPrices = {
+      [TOKENS.BAL.toLowerCase()]: {
+        usd: '10',
+      },
+    };
+    staticTokenPriceProvider = new StaticTokenPriceProvider(tokenPrices);
+    expect(await staticTokenPriceProvider.find(TOKENS.BAL)).to.deep.eq({
+      usd: '10',
+    });
+  });
+});

--- a/balancer-js/src/modules/data/token-prices/static.ts
+++ b/balancer-js/src/modules/data/token-prices/static.ts
@@ -1,11 +1,18 @@
-import { Price, TokenPrices } from '@/types';
-import { TokenPriceProvider } from './types';
+import { Findable, Price, TokenPrices } from '@/types';
 
-export class StaticTokenPriceProvider implements TokenPriceProvider {
-  constructor(private tokenPrices: TokenPrices) {}
+export class StaticTokenPriceProvider implements Findable<Price> {
+  tokenPrices: TokenPrices;
+  constructor(tokenPrices: TokenPrices) {
+    this.tokenPrices = Object.fromEntries(
+      Object.entries(tokenPrices).map(([address, price]) => {
+        return [address.toLowerCase(), price];
+      })
+    );
+  }
 
   async find(address: string): Promise<Price | undefined> {
-    const price = this.tokenPrices[address];
+    const lowercaseAddress = address.toLowerCase();
+    const price = this.tokenPrices[lowercaseAddress];
     if (!price) return;
     return price;
   }

--- a/balancer-js/src/modules/data/token-prices/types.ts
+++ b/balancer-js/src/modules/data/token-prices/types.ts
@@ -1,5 +1,0 @@
-import { Price } from '@/types';
-
-export interface TokenPriceProvider {
-  find: (address: string) => Promise<Price | undefined>;
-}

--- a/balancer-js/src/modules/liquidity/liquidity.module.ts
+++ b/balancer-js/src/modules/liquidity/liquidity.module.ts
@@ -1,6 +1,5 @@
-import { Findable, Pool, PoolToken } from '@/types';
+import { Findable, Pool, PoolToken, Price } from '@/types';
 import { PoolAttribute } from '../data';
-import { TokenPriceProvider } from '../data';
 import { PoolTypeConcerns } from '../pools/pool-type-concerns';
 import { BigNumber } from '@ethersproject/bignumber';
 import { formatFixed, parseFixed } from '@/lib/utils/math';
@@ -15,7 +14,7 @@ export interface PoolBPTValue {
 export class Liquidity {
   constructor(
     private pools: Findable<Pool, PoolAttribute>,
-    private tokenPrices: TokenPriceProvider
+    private tokenPrices: Findable<Price>
   ) {}
 
   async getLiquidity(pool: Pool): Promise<string> {

--- a/balancer-js/src/modules/pools/apr/apr.spec.ts
+++ b/balancer-js/src/modules/pools/apr/apr.spec.ts
@@ -192,6 +192,13 @@ describe('pool apr', () => {
       ).rewardAprs(poolData);
 
       expect(apr.total).to.eq(20000);
+
+      const aprBreakdownSum = Object.values(apr.breakdown).reduce(
+        (total, current) => (total += current),
+        0
+      );
+
+      expect(aprBreakdownSum).to.eq(apr.total);
     });
   });
 });

--- a/balancer-js/src/modules/pools/apr/apr.ts
+++ b/balancer-js/src/modules/pools/apr/apr.ts
@@ -278,12 +278,13 @@ export class PoolApr {
     let total = 0;
     for await (const reward of Object.values(rewards)) {
       const rewardValue = reward.value / totalSupplyUsd;
-      total += rewardValue;
-      rewardTokensBreakdown[reward.address] = reward.value;
+      const rewardValueScaled = Math.round(10000 * rewardValue);
+      total += rewardValueScaled;
+      rewardTokensBreakdown[reward.address] = rewardValueScaled;
     }
 
     return {
-      total: Math.round(10000 * total),
+      total,
       breakdown: rewardTokensBreakdown,
     };
   }

--- a/balancer-js/src/modules/pools/apr/apr.ts
+++ b/balancer-js/src/modules/pools/apr/apr.ts
@@ -418,9 +418,9 @@ export class PoolApr {
       };
     } else {
       const yearlyReward = rewardData.rate.mul(86400).mul(365);
-      const price = await this.tokenPrices.find(tokenAddress.toLowerCase());
+      const price = await this.tokenPrices.find(tokenAddress);
       if (price && price.usd) {
-        const meta = await this.tokenMeta.find(tokenAddress.toLowerCase());
+        const meta = await this.tokenMeta.find(tokenAddress);
         const decimals = meta?.decimals || 18;
         const yearlyRewardUsd =
           parseFloat(formatUnits(yearlyReward, decimals)) *

--- a/balancer-js/src/modules/pools/apr/apr.ts
+++ b/balancer-js/src/modules/pools/apr/apr.ts
@@ -417,9 +417,9 @@ export class PoolApr {
       };
     } else {
       const yearlyReward = rewardData.rate.mul(86400).mul(365);
-      const price = await this.tokenPrices.find(tokenAddress);
+      const price = await this.tokenPrices.find(tokenAddress.toLowerCase());
       if (price && price.usd) {
-        const meta = await this.tokenMeta.find(tokenAddress);
+        const meta = await this.tokenMeta.find(tokenAddress.toLowerCase());
         const decimals = meta?.decimals || 18;
         const yearlyRewardUsd =
           parseFloat(formatUnits(yearlyReward, decimals)) *


### PR DESCRIPTION
@gmbronco mentioned the SDK should always be dealing with token addresses in lower case for consistency. In the Balancer API all tokens are fetched and stored with lower case addresses. The tokens on reward gauges are not in lower case and so in the API it wasn't finding prices correctly. 

This fix ensures that reward tokens are fetched correctly, it appears to be working correctly when running the APR examples and when using it with the API. 

Also found another bug where the rewardBreakdown wasn't being scaled by BPT. Added a fix for that too so the breakdown adds up to the total correctly .