### PR TITLE
adding rocketPool rETH token yield

### DIFF
--- a/balancer-js/src/modules/data/token-yields/repository.ts
+++ b/balancer-js/src/modules/data/token-yields/repository.ts
@@ -1,5 +1,9 @@
 import { lido, yieldTokens as lidoTokens } from './tokens/lido';
 import {
+  rocketpool,
+  yieldTokens as rocketpoolTokens,
+} from './tokens/rocketpool';
+import {
   lidoPolygon,
   yieldTokens as lidoPolygonTokens,
 } from './tokens/lido-polygon';
@@ -21,6 +25,7 @@ const yieldSourceMap: { [address: string]: AprFetcher } = Object.fromEntries([
   ...Object.values(lidoPolygonTokens).map((k) => [k, lidoPolygon]),
   ...Object.values(aaveTokens).map((k) => [k, aave]),
   ...Object.values(overnightTokens).map((k) => [k, overnight]),
+  ...Object.values(rocketpoolTokens).map((k) => [k, rocketpool]),
 ]);
 
 export class TokenYieldsRepository implements Findable<number> {

--- a/balancer-js/src/modules/data/token-yields/tokens/rocketpool.spec.ts
+++ b/balancer-js/src/modules/data/token-yields/tokens/rocketpool.spec.ts
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import { rocketpool, yieldTokens } from './rocketpool';
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+
+const mockedResponse = {
+  yearlyAPR: '1',
+};
+
+describe('rocketpool apr', () => {
+  let mock: MockAdapter;
+
+  before(() => {
+    mock = new MockAdapter(axios);
+    mock
+      .onGet('https://api.rocketpool.net/api/apr')
+      .reply(() => [200, mockedResponse]);
+  });
+
+  after(() => {
+    mock.restore();
+  });
+
+  it('is getting fetched', async () => {
+    const apr = (await rocketpool())[yieldTokens.rETH];
+    expect(apr).to.eq(100);
+  });
+});

--- a/balancer-js/src/modules/data/token-yields/tokens/rocketpool.ts
+++ b/balancer-js/src/modules/data/token-yields/tokens/rocketpool.ts
@@ -1,0 +1,34 @@
+import { AprFetcher } from '../repository';
+import axios from 'axios';
+
+export const yieldTokens = {
+  rETH: '0xae78736cd615f374d3085123a210448e74fc6393',
+};
+
+interface RocketPoolAPIResponse {
+  yearlyAPR: string;
+}
+
+/**
+ * APR fetching
+ *
+ * @returns APR in bsp
+ */
+export const rocketpool: AprFetcher = async () => {
+  let apr = 0;
+
+  try {
+    const response = await axios.get<RocketPoolAPIResponse>(
+      'https://api.rocketpool.net/api/apr'
+    );
+    const { yearlyAPR } = response.data;
+
+    apr = Math.round(parseFloat(yearlyAPR) * 100);
+  } catch (error) {
+    console.error('Failed to fetch APR:', error);
+  }
+
+  return {
+    [yieldTokens.rETH]: apr,
+  };
+};


### PR DESCRIPTION
Adding yield information source for rocketpool rETH.

Each yield generating token has an external source for the yield. It can be anything, eg: a contract, subgraph of API. To add a new source:

1. Create a new source in `modules/data/token-yields/tokens/` with an yieldTokens object and a fetcher. Fetchers return APR for each token in basis points.
2. Add a spec to make sure it works ok and returns a correct format: { tokenAddress: apr }
3. import yieldTokens and a fetching function into [yieldSourceMap](https://github.com/balancer-labs/balancer-sdk/blob/develop/balancer-js/src/modules/data/token-yields/repository.ts#L19).
4. Add a new token to `yieldSourceMap` responsible for mapping token addresses to fetching functions.
5. Test it to make sure repository is returning a new APR.

Thats' it. Now APRs will be able to find a new token and include it in tokenAprs breakdown.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203190245224997