### PR TITLE
Update to work with multihops and fix limits.

### DIFF
--- a/balancer-js/examples/swapSor.ts
+++ b/balancer-js/examples/swapSor.ts
@@ -68,15 +68,17 @@ async function getAndProcessSwaps(
       );
       // Static calling Relayer doesn't return any useful values but will allow confirmation tx is ok
       // relayerCallData.data can be used to simulate tx on Tenderly to see token balance change, etc
+      // console.log(wallet.address);
+      // console.log(await balancer.sor.provider.getBlockNumber());
       // console.log(relayerCallData.data);
       const result = await balancer.contracts.relayerV4
         ?.connect(wallet)
         .callStatic.multicall(relayerCallData.rawCalls);
       console.log(result);
-    } catch (err) {
+    } catch (err: any) {
       // If error we can reprocess without join/exit paths
-      console.log(`Error Using Join/Exit Paths: `, err);
-      getAndProcessSwaps(
+      console.log(`Error Using Join/Exit Paths`, err.reason);
+      await getAndProcessSwaps(
         balancer,
         tokenIn!,
         tokenOut!,
@@ -122,7 +124,7 @@ async function swapExample() {
   const tokenIn = ADDRESSES[network].WETH.address;
   const tokenOut = ADDRESSES[network].auraBal?.address;
   const swapType = SwapTypes.SwapExactIn;
-  const amount = parseFixed('0.8', 18);
+  const amount = parseFixed('18', 18);
   // Currently Relayer only suitable for ExactIn and non-eth swaps
   const canUseJoinExitPaths = canUseJoinExit(swapType, tokenIn!, tokenOut!);
 

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -88,7 +88,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@balancer-labs/sor": "/Users/jg/Documents/sor-sergio/balancer-labs-sor-v4.0.1-beta.9.tgz",
+    "@balancer-labs/sor": "^4.0.1-beta.9",
     "@balancer-labs/typechain": "^1.0.0",
     "axios": "^0.24.0",
     "graphql": "^15.6.1",

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -88,7 +88,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@balancer-labs/sor": "^4.0.1-beta.8",
+    "@balancer-labs/sor": "/Users/jg/Documents/sor-sergio/balancer-labs-sor-v4.0.1-beta.9.tgz",
     "@balancer-labs/typechain": "^1.0.0",
     "axios": "^0.24.0",
     "graphql": "^15.6.1",

--- a/balancer-js/src/modules/swaps/joinAndExit.integration.spec.ts
+++ b/balancer-js/src/modules/swaps/joinAndExit.integration.spec.ts
@@ -15,9 +15,11 @@ import { buildRelayerCalls, someJoinExit } from './joinAndExit';
 import {
   BAL_WETH,
   AURA_BAL_STABLE,
-  B_50WBTC_50WETH,
   getForkedPools,
   GRAVI_AURA,
+  B_50auraBAL_50wstETH,
+  B_stETH_STABLE,
+  B_50WBTC_50WETH,
 } from '@/test/lib/mainnetPools';
 import { MockPoolDataService } from '@/test/lib/mockPool';
 import { ADDRESSES } from '@/test/lib/constants';
@@ -111,6 +113,21 @@ describe('join and exit integration tests', async () => {
     // SwapTypes.SwapExactIn,
     '10' // 10 bsp = 0.1%
   );
+  await testFlow(
+    'swap, join > swap, mulithopswap - WETH[Swap]auraBal, WETH[join]BPT[Swap]auraBAL, WETH[Swap]wstETH[Swap]auraBal',
+    [
+      BAL_WETH,
+      AURA_BAL_STABLE,
+      GRAVI_AURA,
+      B_50auraBAL_50wstETH,
+      B_stETH_STABLE,
+    ],
+    parseFixed('12.3', 18).toString(),
+    ADDRESSES[networkId].WETH,
+    ADDRESSES[networkId].auraBal,
+    '10', // 10 bsp = 0.1%
+    15773550
+  );
   // Removed ExactOut cases for now as Relayer formatting is difficult
   // await testFlow(
   //   'exit',
@@ -148,7 +165,8 @@ async function testFlow(
     symbol: string;
     slot: number;
   },
-  slippage: string
+  slippage: string,
+  blockNumber = 15624161
 ): Promise<void> {
   context(`${description}`, () => {
     // For now we only support ExactIn case
@@ -168,7 +186,7 @@ async function testFlow(
         slots,
         balances,
         jsonRpcUrl as string,
-        15624161
+        blockNumber
       );
       sor = await setUp(networkId, provider, pools);
       await sor.fetchPools();

--- a/balancer-js/src/modules/swaps/joinAndExit.ts
+++ b/balancer-js/src/modules/swaps/joinAndExit.ts
@@ -415,11 +415,11 @@ export function batchSwapActions(
         batchSwaps.limits[a.swap.assetInIndex] = MaxInt256;
       }
       if (a.hasTokenOut) {
-        // We need to add amount for each swap that uses tokenOut to get correct total
+        // We need to add amount for each swap that uses tokenOut to get correct total (should be negative)
         batchSwaps.hasTokenOut = true;
         batchSwaps.limits[a.swap.assetOutIndex] = batchSwaps.limits[
           a.swap.assetOutIndex
-        ].add(a.minOut);
+        ].sub(a.minOut);
       }
       lastSwap = a;
     } else {
@@ -484,6 +484,7 @@ export function getActions(
   );
   const actions: Actions[] = [];
   let opRefKey = 0;
+  let previousAction: Actions = {} as Actions;
   for (const swap of swaps) {
     if (isJoin(swap, assets)) {
       const [joinAction, newOpRefKey] = createJoinAction(
@@ -498,6 +499,7 @@ export function getActions(
       );
       opRefKey = newOpRefKey;
       actions.push(joinAction);
+      previousAction = joinAction;
       continue;
     } else if (isExit(swap, assets)) {
       const [exitAction, newOpRefKey] = createExitAction(
@@ -512,8 +514,10 @@ export function getActions(
       );
       opRefKey = newOpRefKey;
       actions.push(exitAction);
+      previousAction = exitAction;
       continue;
     } else {
+      const amount = swap.amount;
       const [swapAction, newOpRefKey] = createSwapAction(
         swap,
         tokenInIndex,
@@ -525,8 +529,22 @@ export function getActions(
         user,
         relayer
       );
+      if (previousAction.type === ActionType.Swap && amount === '0') {
+        /*
+        If its part of a multihop swap the amount will be 0 (and should remain 0)
+        The source will be same as previous swap so set previous receiver to match sender. Receiver set as is.
+        */
+        previousAction.receiver = previousAction.sender;
+        previousAction.toInternal = previousAction.fromInternal;
+        previousAction.opRef = [];
+        swapAction.sender = previousAction.receiver;
+        swapAction.fromInternal = previousAction.fromInternal;
+        swapAction.amountIn = '0';
+        swapAction.swap.amount = '0';
+      }
       opRefKey = newOpRefKey;
       actions.push(swapAction);
+      previousAction = swapAction;
       continue;
     }
   }
@@ -1060,10 +1078,10 @@ function checkAmounts(
   //   'slippage'
   // );
   // console.log(swapInfo.returnAmount.toString(), 'swapInfo.returnAmount');
-  if (
-    !totalIn.eq(swapInfo.swapAmount) ||
-    !totalOut.eq(subSlippage(swapInfo.returnAmount, BigNumber.from(slippage)))
-  )
+  const diffOut = totalOut.sub(
+    subSlippage(swapInfo.returnAmount, BigNumber.from(slippage))
+  );
+  if (!totalIn.eq(swapInfo.swapAmount) || !diffOut.lt(`3`))
     throw new BalancerError(BalancerErrorCode.RELAY_SWAP_AMOUNTS);
   /* ExactOut case
     // totalIn should equal the return amount from SOR (this is the amount in) plus any slippage allowance

--- a/balancer-js/src/test/lib/mainnetPools.ts
+++ b/balancer-js/src/test/lib/mainnetPools.ts
@@ -42,6 +42,25 @@ export const GRAVI_AURA = factories.subgraphPoolBase.build({
   ],
 });
 
+export const B_stETH_STABLE = factories.subgraphPoolBase.build({
+  id: '0x32296969ef14eb0c6d29669c550d4a0449130230000200000000000000000080',
+  address: '0x32296969Ef14EB0c6d29669C550D4a0449130230'.toLowerCase(),
+  tokens: [
+    factories.subgraphToken.transient({ symbol: 'wETH' }).build(),
+    factories.subgraphToken.transient({ symbol: 'wstETH' }).build(),
+  ],
+  poolType: 'MetaStable',
+});
+
+export const B_50auraBAL_50wstETH = factories.subgraphPoolBase.build({
+  id: '0x0731399bd09ced6765ff1e0cb884bd223298a5a6000200000000000000000398',
+  address: '0x0731399bD09CED6765ff1e0cB884bd223298a5a6'.toLowerCase(),
+  tokens: [
+    factories.subgraphToken.transient({ symbol: 'wstETH' }).build(),
+    factories.subgraphToken.transient({ symbol: 'auraBAL' }).build(),
+  ],
+});
+
 export const getForkedPools = async (
   provider: JsonRpcProvider,
   pools: SubgraphPoolBase[] = [B_50WBTC_50WETH]

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -483,10 +483,9 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/sor@^4.0.1-beta.8":
-  version "4.0.1-beta.8"
-  resolved "https://registry.npmjs.org/@balancer-labs/sor/-/sor-4.0.1-beta.8.tgz"
-  integrity sha512-beg6cwD0z+HDKNmCj1W1Z7ve5SBdWXJoad3TolFMz2gUX02BbtEg9hkwVHJ+LSLi99h8/18W4aM8JzqQH9WwwQ==
+"@balancer-labs/sor@/Users/jg/Documents/sor-sergio/balancer-labs-sor-v4.0.1-beta.9.tgz":
+  version "4.0.1-beta.9"
+  resolved "/Users/jg/Documents/sor-sergio/balancer-labs-sor-v4.0.1-beta.9.tgz#c36bd96f498b6a4974e3dacf606c38af0d0525ee"
   dependencies:
     isomorphic-fetch "^2.2.1"
 
@@ -2899,7 +2898,7 @@ encoding-down@^6.3.0:
 
 encoding@^0.1.11:
   version "0.1.13"
-  resolved "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
   dependencies:
     iconv-lite "^0.6.2"
@@ -3753,7 +3752,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
 
 iconv-lite@^0.6.2:
   version "0.6.3"
-  resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
@@ -3973,7 +3972,7 @@ is-relative@^1.0.0:
 
 is-stream@^1.0.1:
   version "1.1.0"
-  resolved "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
 
 is-unc-path@^1.0.0:
@@ -4007,7 +4006,7 @@ isexe@^2.0.0:
 
 isomorphic-fetch@^2.2.1:
   version "2.2.1"
-  resolved "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==
   dependencies:
     node-fetch "^1.0.1"
@@ -4740,7 +4739,7 @@ node-fetch@2.6.7, node-fetch@^2.6.1, node-fetch@^2.6.7:
 
 node-fetch@^1.0.1:
   version "1.7.3"
-  resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
   dependencies:
     encoding "^0.1.11"

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -483,9 +483,10 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/sor@/Users/jg/Documents/sor-sergio/balancer-labs-sor-v4.0.1-beta.9.tgz":
+"@balancer-labs/sor@^4.0.1-beta.9":
   version "4.0.1-beta.9"
-  resolved "/Users/jg/Documents/sor-sergio/balancer-labs-sor-v4.0.1-beta.9.tgz#c36bd96f498b6a4974e3dacf606c38af0d0525ee"
+  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-4.0.1-beta.9.tgz#5c144de41255fbf924324ee664c96d915096e289"
+  integrity sha512-/ErkccWwijPOuq+wApxP5dsaP3pALye0Sv1C7yn9X7T3f/jIw9YGSw+EfmOCheTqHbWSnmCiJD97iLbW/KggIA==
   dependencies:
     isomorphic-fetch "^2.2.1"
 


### PR DESCRIPTION
- Update SOR package to 4.0.1-beta.9. Fixes example where fallback without join/exit is used
- Fixes join/exit paths to work with combination that includes multihop
- Set limits correctly - need to be negative for tokens leaving vault