### PR TITLE
Add Linear and Managed pool types

### DIFF
--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -228,10 +228,12 @@ export enum PoolType {
   StablePhantom = 'StablePhantom',
   LiquidityBootstrapping = 'LiquidityBootstrapping',
   AaveLinear = 'AaveLinear',
+  Linear = 'Linear',
   ERC4626Linear = 'ERC4626Linear',
   Element = 'Element',
   Gyro2 = 'Gyro2',
   Gyro3 = 'Gyro3',
+  Managed = 'Managed',
 }
 
 export interface Pool {


### PR DESCRIPTION
The frontend currently uses both these types. As part of using the SDK Pool / PoolType / APR's these need to be added here for type compatibility.