### PR TITLE
Fix two minor issues with pool data repositories

### DIFF
--- a/balancer-js/src/modules/data/pool/balancer-api.ts
+++ b/balancer-js/src/modules/data/pool/balancer-api.ts
@@ -54,9 +54,12 @@ export class PoolsBalancerAPIRepository
     };
 
     this.query = {
-      args: options.query?.args || defaultArgs,
-      attrs: options.query?.attrs || defaultAttributes,
+      args: Object.assign({}, options.query?.args || defaultArgs),
+      attrs: Object.assign({}, options.query?.attrs || defaultAttributes),
     };
+
+    // skip is not a valid argument for the Balancer API, it uses nextToken
+    delete this.query.args.skip;
   }
 
   fetchFromCache(options?: PoolsRepositoryFetchOptions): Pool[] {

--- a/balancer-js/src/modules/data/pool/subgraph.ts
+++ b/balancer-js/src/modules/data/pool/subgraph.ts
@@ -86,8 +86,8 @@ export class PoolsSubgraphRepository
       },
     };
 
-    const args = options.query?.args || defaultArgs;
-    const attrs = options.query?.attrs || {};
+    const args = Object.assign({}, options.query?.args || defaultArgs);
+    const attrs = Object.assign({}, options.query?.attrs || {});
 
     this.query = {
       args,


### PR DESCRIPTION
- Make a copy of the args/attrs passed in so they aren't held by reference as this ends up modifying the initial options passed in which can cause confusion.
- Delete the skip arg if a user passes it into the Balancer API as it is not a valid arg.