### PR TITLE
correct npm homepage url

### DIFF
--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.40",
   "description": "JavaScript SDK for interacting with the Balancer Protocol V2",
   "license": "GPL-3.0-only",
-  "homepage": "https://github.com/balancer-labs/balancer-sdk/balancer-js#readme",
+  "homepage": "https://github.com/balancer-labs/balancer-sdk#readme",
   "repository": {
     "type": "git",
     "url": "https://github.com/balancer-labs/balancer-sdk",


### PR DESCRIPTION
minor, but the homepage link on npm is kaputt as linking to folders directly doesn't work on GH. this PR fixes this by linking to the main README. the homepage field is optional, so we can as well remove it since it's the same as the repo url

if we want to have a deep link, afaik the only alternative is a blob https://github.com/balancer-labs/balancer-sdk/blob/master/balancer-js/README.md

up to you!