### PR TITLE
Fix SubgraphPriceRepository overriding customSubgraphUrl provided on SDK config

### DIFF
--- a/balancer-js/src/modules/data/index.ts
+++ b/balancer-js/src/modules/data/index.ts
@@ -116,6 +116,7 @@ export class Data implements BalancerDataRepositories {
     );
 
     const subgraphPriceRepository = new SubgraphPriceRepository(
+      networkConfig.urls.subgraph,
       networkConfig.chainId
     );
 

--- a/balancer-js/src/modules/data/token-prices/subgraph.spec.ts
+++ b/balancer-js/src/modules/data/token-prices/subgraph.spec.ts
@@ -31,7 +31,7 @@ const mockedResponse = {
 
 const addresses = mockedResponse.data.tokens.map((t) => t.address);
 
-const repository = new SubgraphPriceRepository(1);
+const repository = new SubgraphPriceRepository(url, 1);
 
 describe('subgraph price repository', () => {
   let mock: MockAdapter;

--- a/balancer-js/src/modules/data/token-prices/subgraph.ts
+++ b/balancer-js/src/modules/data/token-prices/subgraph.ts
@@ -16,12 +16,10 @@ interface SubgraphPricesResponse {
 }
 
 export class SubgraphPriceRepository implements Findable<Price> {
-  private subgraphUrl: string;
   prices: { [key: string]: Promise<Price> } = {};
   debouncer: Debouncer<TokenPrices, string>;
 
-  constructor(private chainId: Network = 1) {
-    this.subgraphUrl = BALANCER_NETWORK_CONFIG[chainId].urls.subgraph;
+  constructor(private subgraphUrl: string, private chainId: Network = 1) {
     this.debouncer = new Debouncer<TokenPrices, string>(
       this.fetch.bind(this),
       200

--- a/balancer-js/src/modules/data/token-prices/subgraph.ts
+++ b/balancer-js/src/modules/data/token-prices/subgraph.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { Price, Findable, TokenPrices, Network } from '@/types';
 import axios from 'axios';
-import { BALANCER_NETWORK_CONFIG } from '@/lib/constants/config';
 import { Debouncer, tokenAddressForPricing } from '@/lib/utils';
 
 interface SubgraphPricesResponse {


### PR DESCRIPTION
Issue reported by Markus: `customSubgraphUrl` is being ignored on some frontend requests.
Fix: update SubgraphPriceRepository to use customSubgraphUrl provided by SDK config.
At first, this is not an urgent issue, so feel free to review/approve after the holiday break.