### PR TITLE
Add expected amounts out to exit pool methods

### DIFF
--- a/balancer-js/examples/exitExactBPTIn.ts
+++ b/balancer-js/examples/exitExactBPTIn.ts
@@ -57,11 +57,8 @@ async function exitExactBPTIn() {
     await getBalances([pool.address, ...pool.tokensList], signer, signerAddress)
   ).map((b) => b.toString());
 
-  const { to, data, minAmountsOut } = pool.buildExitExactBPTIn(
-    signerAddress,
-    bptIn,
-    slippage
-  );
+  const { to, data, expectedAmountsOut, minAmountsOut } =
+    pool.buildExitExactBPTIn(signerAddress, bptIn, slippage);
 
   // Submit exit tx
   const transactionResponse = await signer.sendTransaction({
@@ -77,12 +74,10 @@ async function exitExactBPTIn() {
     await getBalances([pool.address, ...pool.tokensList], signer, signerAddress)
   ).map((b) => b.toString());
 
-  console.log('Balances before exit:             ', tokenBalancesBefore);
-  console.log('Balances after exit:              ', tokenBalancesAfter);
-  console.log(
-    'Min balances expected after exit: ',
-    minAmountsOut.map((a) => a.toString())
-  );
+  console.log('Balances before exit:                  ', tokenBalancesBefore);
+  console.log('Balances after exit:                   ', tokenBalancesAfter);
+  console.log('Balances expected after exit:          ', expectedAmountsOut);
+  console.log('Min balances after exit (slippage):    ', minAmountsOut);
 }
 
 // yarn examples:run ./examples/exitExactBPTIn.ts

--- a/balancer-js/examples/exitExactTokensOut.ts
+++ b/balancer-js/examples/exitExactTokensOut.ts
@@ -49,7 +49,7 @@ async function exitExactTokensOut() {
   ]; // Tokens that will be provided to pool by joiner
   const amountsOut = ['10000000', '1000000000000000000'];
 
-  const { to, data, maxBPTIn } = pool.buildExitExactTokensOut(
+  const { to, data, expectedBPTIn, maxBPTIn } = pool.buildExitExactTokensOut(
     signerAddress,
     tokensOut as string[],
     amountsOut,
@@ -86,12 +86,8 @@ async function exitExactTokensOut() {
 
   console.log('Balances before exit:                 ', tokenBalancesBefore);
   console.log('Balances after exit:                  ', tokenBalancesAfter);
-  console.log('Max BPT input:                        ', [maxBPTIn.toString()]);
-  console.log('Actual BPT input:                     ', [
-    BigNumber.from(tokenBalancesBefore[0])
-      .sub(BigNumber.from(tokenBalancesAfter[0]))
-      .toString(),
-  ]);
+  console.log('Expected BPT input:                   ', expectedBPTIn);
+  console.log('Max BPT input (slippage):             ', maxBPTIn);
 }
 
 // yarn examples:run ./examples/exitExactTokensOut.ts

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exit.concern.ts
@@ -1,12 +1,13 @@
 import {
   ExitConcern,
-  ExitExactBPTInSingleTokenOutParameters,
+  ExitExactBPTInParameters,
   ExitExactTokensOutParameters,
-  ExitPoolAttributes,
+  ExitExactBPTInAttributes,
+  ExitExactTokensOutAttributes,
 } from '../types';
 
 export class ComposableStablePoolExit implements ExitConcern {
-  buildExitSingleTokenOut = ({
+  buildExitExactBPTIn = ({
     exiter,
     pool,
     bptIn,
@@ -14,7 +15,7 @@ export class ComposableStablePoolExit implements ExitConcern {
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
     singleTokenMaxOut,
-  }: ExitExactBPTInSingleTokenOutParameters): ExitPoolAttributes => {
+  }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
     // TODO implementation
     console.log(
       exiter,
@@ -36,7 +37,7 @@ export class ComposableStablePoolExit implements ExitConcern {
     amountsOut,
     slippage,
     wrappedNativeAsset,
-  }: ExitExactTokensOutParameters): ExitPoolAttributes => {
+  }: ExitExactTokensOutParameters): ExitExactTokensOutAttributes => {
     // TODO implementation
     console.log(
       exiter,

--- a/balancer-js/src/modules/pools/pool-types/concerns/linear/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/linear/exit.concern.ts
@@ -2,7 +2,8 @@ import {
   ExitConcern,
   ExitExactBPTInParameters,
   ExitExactTokensOutParameters,
-  ExitPoolAttributes,
+  ExitExactBPTInAttributes,
+  ExitExactTokensOutAttributes,
 } from '../types';
 
 export class LinearPoolExit implements ExitConcern {
@@ -14,7 +15,7 @@ export class LinearPoolExit implements ExitConcern {
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
     singleTokenMaxOut,
-  }: ExitExactBPTInParameters): ExitPoolAttributes => {
+  }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
     // TODO implementation
     console.log(
       exiter,
@@ -35,7 +36,7 @@ export class LinearPoolExit implements ExitConcern {
     amountsOut,
     slippage,
     wrappedNativeAsset,
-  }: ExitExactTokensOutParameters): ExitPoolAttributes => {
+  }: ExitExactTokensOutParameters): ExitExactTokensOutAttributes => {
     // TODO implementation
     console.log(
       exiter,

--- a/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.integration.spec.ts
@@ -250,9 +250,8 @@ describe('exit meta stable pools execution', async () => {
             tokensBalanceAfter[i]
               .sub(tokensBalanceBefore[i])
               .sub(tokensMinBalanceIncrease[i])
-              .abs()
-              .lte(1)
-          ).to.be.true;
+              .toNumber()
+          ).to.be.closeTo(0, 1);
         }
       });
 

--- a/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/metaStable/exit.concern.ts
@@ -5,7 +5,8 @@ import {
   ExitExactBPTInParameters,
   ExitExactTokensOutParameters,
   ExitPool,
-  ExitPoolAttributes,
+  ExitExactBPTInAttributes,
+  ExitExactTokensOutAttributes,
 } from '../types';
 import { AssetHelpers, isSameAddress, parsePoolInfo } from '@/lib/utils';
 import { Vault__factory } from '@balancer-labs/typechain';
@@ -24,7 +25,7 @@ export class MetaStablePoolExit implements ExitConcern {
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
     singleTokenMaxOut,
-  }: ExitExactBPTInParameters): ExitPoolAttributes => {
+  }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
     if (!bptIn.length || parseFixed(bptIn, 18).isNegative()) {
       throw new BalancerError(BalancerErrorCode.INPUT_OUT_OF_BOUNDS);
     }
@@ -82,6 +83,7 @@ export class MetaStablePoolExit implements ExitConcern {
         .toString();
     });
 
+    let expectedAmountsOut = Array(parsedTokens.length).fill('0');
     let minAmountsOut = Array(parsedTokens.length).fill('0');
     let userData: string;
 
@@ -106,6 +108,8 @@ export class MetaStablePoolExit implements ExitConcern {
         .mul(parseFixed('1', 18))
         .toString();
 
+      expectedAmountsOut[singleTokenMaxOutIndex] = amountOut;
+
       minAmountsOut[singleTokenMaxOutIndex] = subSlippage(
         BigNumber.from(amountOut),
         BigNumber.from(slippage)
@@ -127,7 +131,7 @@ export class MetaStablePoolExit implements ExitConcern {
         ).map((amount) => amount.toString());
 
       // Reverse scaled amounts out based on token price rate
-      const amountsOut = scaledAmountsOut.map((amount, i) => {
+      expectedAmountsOut = scaledAmountsOut.map((amount, i) => {
         return BigNumber.from(amount)
           .div(BigNumber.from(sortedPriceRates[i]))
           .mul(parseFixed('1', 18))
@@ -135,7 +139,7 @@ export class MetaStablePoolExit implements ExitConcern {
       });
 
       // Apply slippage tolerance
-      minAmountsOut = amountsOut.map((amount) => {
+      minAmountsOut = expectedAmountsOut.map((amount) => {
         const minAmount = subSlippage(
           BigNumber.from(amount),
           BigNumber.from(slippage)
@@ -174,8 +178,8 @@ export class MetaStablePoolExit implements ExitConcern {
       functionName,
       attributes,
       data,
+      expectedAmountsOut,
       minAmountsOut,
-      maxBPTIn: bptIn,
     };
   };
 
@@ -186,7 +190,7 @@ export class MetaStablePoolExit implements ExitConcern {
     amountsOut,
     slippage,
     wrappedNativeAsset,
-  }: ExitExactTokensOutParameters): ExitPoolAttributes => {
+  }: ExitExactTokensOutParameters): ExitExactTokensOutAttributes => {
     if (
       tokensOut.length != amountsOut.length ||
       tokensOut.length != pool.tokensList.length
@@ -293,7 +297,7 @@ export class MetaStablePoolExit implements ExitConcern {
       functionName,
       attributes,
       data,
-      minAmountsOut,
+      expectedBPTIn: bptIn,
       maxBPTIn,
     };
   };

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
@@ -1,3 +1,4 @@
+// yarn test:only ./src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
 import dotenv from 'dotenv';
 import { expect } from 'chai';
 import { BalancerSDK, Network, Pool } from '@/.';
@@ -9,7 +10,6 @@ import { forkSetup, getBalances } from '@/test/lib/utils';
 import { Pools } from '@/modules/pools';
 
 import pools_14717479 from '@/test/lib/pools_14717479.json';
-import { ExitPoolAttributes } from '../types';
 
 dotenv.config();
 
@@ -66,7 +66,7 @@ describe('exit stable pools execution', async () => {
   });
 
   const testFlow = async (
-    { to, data, maxBPTIn, minAmountsOut }: ExitPoolAttributes,
+    [to, data, maxBPTIn, minAmountsOut]: [string, string, string, string[]],
     exitTokens: string[],
     exitWithETH = false
   ) => {
@@ -110,10 +110,12 @@ describe('exit stable pools execution', async () => {
     context('proportional amounts out', async () => {
       before(async function () {
         const bptIn = parseFixed('10', 18).toString();
-        await testFlow(
-          controller.buildExitExactBPTIn(signerAddress, bptIn, slippage),
-          pool.tokensList
+        const { to, data, minAmountsOut } = controller.buildExitExactBPTIn(
+          signerAddress,
+          bptIn,
+          slippage
         );
+        await testFlow([to, data, bptIn, minAmountsOut], pool.tokensList);
       });
 
       it('should work', async () => {
@@ -138,16 +140,14 @@ describe('exit stable pools execution', async () => {
     context('single token max out', async () => {
       before(async function () {
         const bptIn = parseFixed('10', 18).toString();
-        await testFlow(
-          controller.buildExitExactBPTIn(
-            signerAddress,
-            bptIn,
-            slippage,
-            false,
-            pool.tokensList[0]
-          ),
-          pool.tokensList
+        const { to, data, minAmountsOut } = controller.buildExitExactBPTIn(
+          signerAddress,
+          bptIn,
+          slippage,
+          false,
+          pool.tokensList[0]
         );
+        await testFlow([to, data, bptIn, minAmountsOut], pool.tokensList);
       });
 
       it('should work', async () => {
@@ -181,15 +181,14 @@ describe('exit stable pools execution', async () => {
             .toString()
         );
 
-        await testFlow(
-          controller.buildExitExactTokensOut(
-            signerAddress,
-            tokensOut.map((t) => t.address),
-            amountsOut,
-            slippage
-          ),
-          pool.tokensList
+        const { to, data, maxBPTIn } = controller.buildExitExactTokensOut(
+          signerAddress,
+          tokensOut.map((t) => t.address),
+          amountsOut,
+          slippage
         );
+
+        await testFlow([to, data, maxBPTIn, amountsOut], pool.tokensList);
       });
 
       it('should work', async () => {
@@ -223,15 +222,14 @@ describe('exit stable pools execution', async () => {
           return '0';
         });
 
-        await testFlow(
-          controller.buildExitExactTokensOut(
-            signerAddress,
-            tokensOut.map((t) => t.address),
-            amountsOut,
-            slippage
-          ),
-          pool.tokensList
+        const { to, data, maxBPTIn } = controller.buildExitExactTokensOut(
+          signerAddress,
+          tokensOut.map((t) => t.address),
+          amountsOut,
+          slippage
         );
+
+        await testFlow([to, data, maxBPTIn, amountsOut], pool.tokensList);
       });
 
       it('should work', async () => {

--- a/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stablePhantom/exit.concern.ts
@@ -2,7 +2,8 @@ import {
   ExitConcern,
   ExitExactBPTInParameters,
   ExitExactTokensOutParameters,
-  ExitPoolAttributes,
+  ExitExactBPTInAttributes,
+  ExitExactTokensOutAttributes,
 } from '../types';
 
 export class StablePhantomPoolExit implements ExitConcern {
@@ -14,7 +15,7 @@ export class StablePhantomPoolExit implements ExitConcern {
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
     singleTokenMaxOut,
-  }: ExitExactBPTInParameters): ExitPoolAttributes => {
+  }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
     // TODO implementation
     console.log(
       exiter,
@@ -35,7 +36,7 @@ export class StablePhantomPoolExit implements ExitConcern {
     amountsOut,
     slippage,
     wrappedNativeAsset,
-  }: ExitExactTokensOutParameters): ExitPoolAttributes => {
+  }: ExitExactTokensOutParameters): ExitExactTokensOutAttributes => {
     // TODO implementation
     console.log(
       exiter,

--- a/balancer-js/src/modules/pools/pool-types/concerns/types.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/types.ts
@@ -51,7 +51,7 @@ export interface ExitConcern {
     shouldUnwrapNativeAsset,
     wrappedNativeAsset,
     singleTokenMaxOut,
-  }: ExitExactBPTInParameters) => ExitPoolAttributes;
+  }: ExitExactBPTInParameters) => ExitExactBPTInAttributes;
 
   /**
    * Build exit pool transaction parameters with exact tokens out and maximum BPT in based on slippage tolerance
@@ -70,17 +70,7 @@ export interface ExitConcern {
     amountsOut,
     slippage,
     wrappedNativeAsset,
-  }: ExitExactTokensOutParameters) => ExitPoolAttributes;
-
-  buildExitSingleTokenOut?: ({
-    exiter,
-    pool,
-    bptIn,
-    slippage,
-    shouldUnwrapNativeAsset,
-    wrappedNativeAsset,
-    singleTokenMaxOut,
-  }: ExitExactBPTInSingleTokenOutParameters) => ExitPoolAttributes;
+  }: ExitExactTokensOutParameters) => ExitExactTokensOutAttributes;
 }
 
 export interface JoinPool {
@@ -115,12 +105,38 @@ export interface ExitPool {
   exitPoolRequest: ExitPoolRequest;
 }
 
-export interface ExitPoolAttributes {
+interface ExitPoolAttributes {
   to: string;
   functionName: string;
   attributes: ExitPool;
   data: string;
+}
+
+/**
+ * Exit exact BPT in transaction parameters
+ * @param to Address that will execute the transaction (vault address)
+ * @param functionName Function name to be called (exitPool)
+ * @param attributes Transaction attributes ready to be encoded
+ * @param data Encoded transaction data
+ * @param expectedAmountsOut Expected amounts out of exit transaction
+ * @param minAmountsOut Minimum amounts out of exit transaction considering slippage tolerance
+ */
+export interface ExitExactBPTInAttributes extends ExitPoolAttributes {
+  expectedAmountsOut: string[];
   minAmountsOut: string[];
+}
+
+/**
+ * Exit exact tokens out transaction parameters
+ * @param to Address that will execute the transaction (vault address)
+ * @param functionName Function name to be called (exitPool)
+ * @param attributes Transaction attributes ready to be encoded
+ * @param data Encoded transaction data
+ * @param expectedBPTIn Expected BPT into exit transaction
+ * @param maxBPTIn Max BPT into exit transaction considering slippage tolerance
+ */
+export interface ExitExactTokensOutAttributes extends ExitPoolAttributes {
+  expectedBPTIn: string;
   maxBPTIn: string;
 }
 

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -3,7 +3,8 @@ import type { BigNumberish } from '@ethersproject/bignumber';
 import type { Contract } from '@ethersproject/contracts';
 import type { PoolDataService, TokenPriceService } from '@balancer-labs/sor';
 import type {
-  ExitPoolAttributes,
+  ExitExactBPTInAttributes,
+  ExitExactTokensOutAttributes,
   JoinPoolAttributes,
 } from './modules/pools/pool-types/concerns/types';
 import type {
@@ -331,13 +332,13 @@ export interface PoolWithMethods extends Pool, Queries.ParamsBuilder {
     slippage: string,
     shouldUnwrapNativeAsset?: boolean,
     singleTokenMaxOut?: string
-  ) => ExitPoolAttributes;
+  ) => ExitExactBPTInAttributes;
   buildExitExactTokensOut: (
     exiter: string,
     tokensOut: string[],
     amountsOut: string[],
     slippage: string
-  ) => ExitPoolAttributes;
+  ) => ExitExactTokensOutAttributes;
   calcSpotPrice: (tokenIn: string, tokenOut: string) => string;
 }
 


### PR DESCRIPTION
See [Asana](https://app.asana.com/0/1201380039585484/1203677866180075/f)

- Add `expectedAmountsOut` to `exitExactBPTIn` output on exit concerns
- Add `expectedBPTIn` to `exitExactTokensOut` output on exit concerns
- Remove `maxBPTIn` from `exitExactBPTIn` output on exit concerns since they simply replicate user input `bptIn`
- Remove `minAmountOut` from `exitExactTokensOut` output on exit concerns since they simply replicate user input `amountsOut`
- Update examples and readme to reflect changes