### PR TITLE
Fetch ALCHEMY_URL in a more reliable way

### DIFF
--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "eslint ./src --ext .ts --max-warnings 0 --fix",
     "subgraph:generate": "graphql-codegen --config src/modules/subgraph/codegen.yml -r dotenv/config",
     "examples:run": "npx ts-node -P tsconfig.testing.json -r tsconfig-paths/register",
-    "node": "npx hardhat node --tsconfig tsconfig.testing.json --fork $(grep ALCHEMY_URL .env | cut -d '=' -f2 | tail -1)",
+    "node": "npx hardhat node --tsconfig tsconfig.testing.json --fork $(. ./.env && echo $ALCHEMY_URL)",
     "node:goerli": "npx hardhat --tsconfig tsconfig.testing.json --config hardhat.config.goerli.ts node --fork $(grep ALCHEMY_URL_GOERLI .env | cut -d '=' -f2 | tail -1) --port 8000"
   },
   "devDependencies": {


### PR DESCRIPTION
I was running into some weird issues running the hardhat fork because my .env file looked like this:

```
ALCHEMY_URL=https://eth-mainnet.alchemyapi.io/v2/...
# ALCHEMY_URL=https://polygon-mainnet.g.alchemy.com/v2/...
```

Took a while to discover this grep was picking up the polygon url despite it being commented out because it was the last ALCHEMY_URL in the file. 

Sourcing this file then echoing the value should be more reliable. This works on Ubuntu 22.04, please test it works on OSX before merging. 