### PR TITLE
👨‍🔧build issues with direct ethers/lib import

### DIFF
--- a/balancer-js/.eslintrc.js
+++ b/balancer-js/.eslintrc.js
@@ -7,5 +7,20 @@ module.exports = {
     'comma-spacing': ['error', { before: false, after: true }],
     'prettier/prettier': 'error',
     'mocha-no-only/mocha-no-only': ['error'],
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            // Avoid imports using 'ethers*' because they lead to compilation issues in rollup builds
+            // Probably related to rollup config not being able to resolve the 'ethers*'
+            // migrate to: imports (globals: { ethers: 'ethers' }) once we switch to ethers vs individual packages
+            group: ['ethers*'],
+            message:
+              "import from '@ethersproject/*' instead to avoid rollup build issues",
+          },
+        ],
+      },
+    ]
   },
 };

--- a/balancer-js/src/lib/utils/slippageHelper.spec.ts
+++ b/balancer-js/src/lib/utils/slippageHelper.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { BigNumber } from 'ethers';
+import { BigNumber } from '@ethersproject/bignumber';
 import { subSlippage, addSlippage } from './slippageHelper';
 
 describe('slippage helper', () => {

--- a/balancer-js/src/modules/data/token-yields/tokens/tranchess.spec.ts
+++ b/balancer-js/src/modules/data/token-yields/tokens/tranchess.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { tranchess, yieldTokens } from './tranchess';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
-import { parseEther } from 'ethers/lib/utils';
+import { parseEther } from '@ethersproject/units';
 
 const mockedResponse = [
   {

--- a/balancer-js/src/modules/data/token-yields/tokens/tranchess.ts
+++ b/balancer-js/src/modules/data/token-yields/tokens/tranchess.ts
@@ -1,5 +1,5 @@
-import { BigNumber } from 'ethers';
-import { formatEther } from 'ethers/lib/utils';
+import { BigNumber } from '@ethersproject/bignumber';
+import { formatEther } from '@ethersproject/units';
 import { AprFetcher } from '../repository';
 import axios from 'axios';
 

--- a/balancer-js/src/modules/swaps/swaps.module.integration.spec.ts
+++ b/balancer-js/src/modules/swaps/swaps.module.integration.spec.ts
@@ -6,7 +6,7 @@ import { AddressZero, MaxUint256 } from '@ethersproject/constants';
 import { SwapInfo } from '@balancer-labs/sor';
 import hardhat from 'hardhat';
 import { JsonRpcProvider, TransactionReceipt } from '@ethersproject/providers';
-import { BigNumber } from 'ethers';
+import { BigNumber } from '@ethersproject/bignumber';
 import { getForkedPools } from '@/test/lib/mainnetPools';
 
 dotenv.config();


### PR DESCRIPTION
Current build breaks because of direct 'ethers*' imports
Probably related to rollup config not being able to resolve the 'ethers*'
Migrate to: imports (globals: { ethers: 'ethers' }) once we switch to ethers vs individual packages