### PR TITLE
Update to SOR 4.1.0-beta.0. Add config for SOR connecting tokens.

### DIFF
--- a/balancer-js/examples/swapSor.ts
+++ b/balancer-js/examples/swapSor.ts
@@ -16,7 +16,7 @@ import {
   canUseJoinExit,
 } from '../src/index';
 
-import { ADDRESSES } from '../src/test/lib/constants';
+import { ADDRESSES, PROVIDER_URLS } from '../src/test/lib/constants';
 
 dotenv.config();
 
@@ -119,12 +119,12 @@ async function getAndProcessSwaps(
 }
 
 async function swapExample() {
-  const network = Network.MAINNET;
-  const rpcUrl = `https://mainnet.infura.io/v3/${process.env.INFURA}`;
-  const tokenIn = ADDRESSES[network].WETH.address;
-  const tokenOut = ADDRESSES[network].auraBal?.address;
+  const network = Network.POLYGON;
+  const rpcUrl = PROVIDER_URLS[network];
+  const tokenIn = ADDRESSES[network].USDC.address;
+  const tokenOut = ADDRESSES[network].brz.address;
   const swapType = SwapTypes.SwapExactIn;
-  const amount = parseFixed('18', 18);
+  const amount = parseFixed('200', 6);
   // Currently Relayer only suitable for ExactIn and non-eth swaps
   const canUseJoinExitPaths = canUseJoinExit(swapType, tokenIn!, tokenOut!);
 

--- a/balancer-js/package.json
+++ b/balancer-js/package.json
@@ -81,7 +81,7 @@
     "typescript": "^4.0.2"
   },
   "dependencies": {
-    "@balancer-labs/sor": "^4.0.1-beta.18",
+    "@balancer-labs/sor": "^4.1.0-beta.0",
     "@balancer-labs/typechain": "^1.0.0",
     "@ethersproject/abi": "^5.4.0",
     "@ethersproject/abstract-signer": "^5.4.0",

--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -55,6 +55,20 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     poolsToIgnore: [
       '0xbd482ffb3e6e50dc1c437557c3bea2b68f3683ee', // a pool made by an external dev who was playing with a novel rate provider mechanism in production.
     ],
+    sorConnectingTokens: [
+      {
+        symbol: 'wEth',
+        address: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
+      },
+      {
+        symbol: 'wstEth',
+        address: '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0',
+      },
+      {
+        symbol: 'DOLA',
+        address: '0x865377367054516e17014CcdED1e7d814EDC9ce4',
+      },
+    ],
   },
   [Network.POLYGON]: {
     chainId: Network.POLYGON, //137
@@ -86,6 +100,16 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
     poolsToIgnore: [
       '0x600bd01b6526611079e12e1ff93aba7a3e34226f', // This pool has rateProviders with incorrect scaling
     ],
+    sorConnectingTokens: [
+      {
+        symbol: 'weth',
+        address: '0x0d500B1d8E8eF31E21C99d1Db9A6444d3ADf1270',
+      },
+      {
+        symbol: 'bbrz2',
+        address: '0xe22483774bd8611be2ad2f4194078dac9159f4ba',
+      }, // Joins Stables<>BRZ via https://app.balancer.fi/#/polygon/pool/0x4a0b73f0d13ff6d43e304a174697e3d5cfd310a400020000000000000000091c
+    ],
   },
   [Network.ARBITRUM]: {
     chainId: Network.ARBITRUM, //42161
@@ -114,6 +138,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         'https://api.thegraph.com/subgraphs/name/ianlapham/arbitrum-one-blocks',
     },
     pools: {},
+    sorConnectingTokens: [
+      {
+        symbol: 'weth',
+        address: '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1',
+      },
+    ],
   },
   [Network.KOVAN]: {
     chainId: Network.KOVAN, //42
@@ -207,6 +237,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
         'https://api.thegraph.com/subgraphs/name/blocklytics/goerli-blocks',
     },
     pools: {},
+    sorConnectingTokens: [
+      {
+        symbol: 'weth',
+        address: '0xdFCeA9088c8A88A76FF74892C1457C17dfeef9C1',
+      },
+    ],
   },
   [Network.OPTIMISM]: {
     chainId: Network.OPTIMISM, //10
@@ -231,6 +267,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph: '',
     },
     pools: {},
+    sorConnectingTokens: [
+      {
+        symbol: 'weth',
+        address: '0x4200000000000000000000000000000000000006',
+      },
+    ],
   },
   [Network.GNOSIS]: {
     chainId: Network.GNOSIS, //100
@@ -254,6 +296,12 @@ export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
       gaugesSubgraph: '',
     },
     pools: {},
+    sorConnectingTokens: [
+      {
+        symbol: 'weth',
+        address: '0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d',
+      },
+    ],
   },
 };
 

--- a/balancer-js/src/modules/sor/sor.module.ts
+++ b/balancer-js/src/modules/sor/sor.module.ts
@@ -59,6 +59,7 @@ export class Sor extends SOR {
       weth: network.addresses.tokens.wrappedNativeAsset,
       lbpRaisingTokens: network.addresses.tokens?.lbpRaisingTokens,
       wETHwstETH: network.pools.wETHwstETH,
+      connectingTokens: network.sorConnectingTokens,
     };
   }
 

--- a/balancer-js/src/test/lib/constants.ts
+++ b/balancer-js/src/test/lib/constants.ts
@@ -1,5 +1,16 @@
+import dotenv from 'dotenv';
 import { Network } from '@/lib/constants/network';
 import { AddressZero } from '@ethersproject/constants';
+
+dotenv.config();
+
+export const PROVIDER_URLS = {
+  [Network.MAINNET]: `https://mainnet.infura.io/v3/${process.env.INFURA}`,
+  [Network.GOERLI]: `https://goerli.infura.io/v3/${process.env.INFURA}`,
+  [Network.KOVAN]: `https://kovan.infura.io/v3/${process.env.INFURA}`,
+  [Network.POLYGON]: `https://polygon-mainnet.infura.io/v3/${process.env.INFURA}`,
+  [Network.ARBITRUM]: `https://arbitrum-mainnet.infura.io/v3/${process.env.INFURA}`,
+};
 
 export const ADDRESSES = {
   [Network.MAINNET]: {
@@ -341,6 +352,11 @@ export const ADDRESSES = {
       decimals: 18,
       symbol: 'bb-am-usd',
       slot: 0,
+    },
+    brz: {
+      address: '0x491a4eb4f1fc3bff8e1d2fc856a6a46663ad556f',
+      decimals: 4,
+      symbol: 'BRZ',
     },
   },
   [Network.ARBITRUM]: {

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -101,6 +101,7 @@ export interface BalancerNetworkConfig {
     wETHwstETH?: PoolReference;
   };
   poolsToIgnore?: string[];
+  sorConnectingTokens?: { symbol: string; address: string }[];
 }
 
 export interface BalancerDataRepositories {

--- a/balancer-js/yarn.lock
+++ b/balancer-js/yarn.lock
@@ -503,10 +503,10 @@
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
-"@balancer-labs/sor@^4.0.1-beta.18":
-  version "4.0.1-beta.18"
-  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-4.0.1-beta.18.tgz#811af4b41f8e9f670c1a38e5f5f2f131d28178ed"
-  integrity sha512-tNY9OIptCVCysSYY6QKBIpJleM66DMKRK78t1WOG1boJbay3kCm+x9R4+6LN5n05gDYM0PE2QwCPytOxzkrCfA==
+"@balancer-labs/sor@^4.1.0-beta.0":
+  version "4.1.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@balancer-labs/sor/-/sor-4.1.0-beta.0.tgz#9d22921bd805381b9d78cff5e5e62331b48c4e5e"
+  integrity sha512-NwnaB307u+3NCwhV4ro/jiyWgsaJQ2F7mcjBnUYrtXjDzGCMCM+0+mW21hnSBprJYZ55T6LEFAQAK0ADDT/uLQ==
   dependencies:
     isomorphic-fetch "^2.2.1"
 


### PR DESCRIPTION
- Update SOR package to [4.1.0-beta.0](https://github.com/balancer-labs/balancer-sor/releases/tag/4.1.0-beta.0).
  -  Adds configurable connecting tokens for Boosted Paths where pools containing tokenIn/Out and connectingTokens will be used in Boosted Path creation.
- Add `sorConnectingTokens` with some initial token details.