### PR TITLE
Fix calculateLiquidity exception when sub-pool totalShares is 0

### DIFF
--- a/balancer-js/src/modules/liquidity/liquidity.module.spec.ts
+++ b/balancer-js/src/modules/liquidity/liquidity.module.spec.ts
@@ -88,6 +88,12 @@ describe('Liquidity Module', () => {
       const liquidity = await liquidityProvider.getLiquidity(pool);
       expect(liquidity).to.be.eq('7781301.384420056605162613');
     });
+
+    it('Should return 0 and not throw an error if totalShares of a sub-pool is 0', async () => {
+      const pool = findPool('0xd4e2af4507b6b89333441c0c398edffb40f86f4d');
+      const liquidity = await liquidityProvider.getLiquidity(pool);
+      expect(liquidity).to.be.eq('0');
+    });
   });
 
   context('Stable Pool calculations', () => {

--- a/balancer-js/src/modules/liquidity/liquidity.module.ts
+++ b/balancer-js/src/modules/liquidity/liquidity.module.ts
@@ -32,9 +32,9 @@ export class Liquidity {
         const liquidity = parseFixed(await this.getLiquidity(pool), SCALE);
         const totalBPT = parseFixed(pool.totalShares, SCALE);
         const bptInParentPool = parseFixed(token.balance, SCALE);
-        const liquidityInParentPool = liquidity
-          .mul(bptInParentPool)
-          .div(totalBPT);
+        const liquidityInParentPool = totalBPT.eq(0)
+          ? 0
+          : liquidity.mul(bptInParentPool).div(totalBPT);
 
         return {
           address: pool.address,

--- a/balancer-js/src/test/fixtures/liquidityPools.json
+++ b/balancer-js/src/test/fixtures/liquidityPools.json
@@ -559,7 +559,9 @@
     "totalSwapFee": "28947.04530037270938008629720776634",
     "chainId": 1,
     "totalLiquidity": "634448.98518992614430606016",
-    "graphData": { "totalLiquidity": "640698.368476791206945358004321879" },
+    "graphData": {
+      "totalLiquidity": "640698.368476791206945358004321879"
+    },
     "swapFee": "0.01",
     "upperTarget": null,
     "tokens": [
@@ -627,7 +629,9 @@
     "totalSwapFee": "5353.322784457539488546921754750037",
     "chainId": 1,
     "totalLiquidity": "60.450842422483721371046222",
-    "graphData": { "totalLiquidity": "107.0540296058752735129733507284743" },
+    "graphData": {
+      "totalLiquidity": "107.0540296058752735129733507284743"
+    },
     "swapFee": "0.01",
     "upperTarget": null,
     "tokens": [
@@ -1098,7 +1102,9 @@
         "priceRate": "1",
         "symbol": "AKITA",
         "decimals": 18,
-        "token": { "pool": null }
+        "token": {
+          "pool": null
+        }
       },
       {
         "address": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
@@ -1107,10 +1113,216 @@
         "priceRate": "1",
         "symbol": "WETH",
         "decimals": 18,
-        "token": { "pool": null }
+        "token": {
+          "pool": null
+        }
       }
     ],
     "protocolYieldFeeCache": null,
     "priceRateProviders": []
+  },
+  {
+    "feesSnapshot": "0",
+    "tokensList": [
+      "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+      "0xf506984c16737b1a9577cadeda02a49fd612aff8"
+    ],
+    "apr": {
+      "protocolApr": 0,
+      "min": 0,
+      "max": 0,
+      "rewardAprs": {
+        "total": 0,
+        "breakdown": {}
+      },
+      "stakingApr": {
+        "max": 0,
+        "min": 0
+      },
+      "swapFees": 0,
+      "tokenAprs": {
+        "total": 0,
+        "breakdown": {}
+      }
+    },
+    "holdersCount": "0",
+    "swapEnabled": true,
+    "symbol": "50USDC-5013WMATIC-13WBTC-13USDC-13LINK-13WETH-13COMP-13BAL-13USDT",
+    "poolType": "Weighted",
+    "volumeSnapshot": "0",
+    "address": "0xd4e2af4507b6b89333441c0c398edffb40f86f4d",
+    "lastUpdate": 1670946730908,
+    "name": "50USDC-5013WMATIC-13WBTC-13USDC-13LINK-13WETH-13COMP-13BAL-13USDT",
+    "totalWeight": "1",
+    "swapsCount": "0",
+    "totalSwapFee": "0",
+    "chainId": 137,
+    "totalLiquidity": "0",
+    "swapFee": "0.01",
+    "id": "0xd4e2af4507b6b89333441c0c398edffb40f86f4d000200000000000000000153",
+    "tokens": [
+      {
+        "symbol": "USDC",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 6,
+        "name": "USD Coin (PoS)",
+        "weight": "0.5",
+        "id": "0xd4e2af4507b6b89333441c0c398edffb40f86f4d000200000000000000000153-0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "invested": "0"
+      },
+      {
+        "symbol": "13WMATIC-13WBTC-13USDC-13LINK-13WETH-13COMP-13BAL-13USDT",
+        "address": "0xf506984c16737b1a9577cadeda02a49fd612aff8",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 18,
+        "name": "13WMATIC-13WBTC-13USDC-13LINK-13WETH-13COMP-13BAL-13USDT",
+        "weight": "0.5",
+        "id": "0xd4e2af4507b6b89333441c0c398edffb40f86f4d000200000000000000000153-0xf506984c16737b1a9577cadeda02a49fd612aff8",
+        "invested": "0"
+      }
+    ],
+    "totalSwapVolume": "0",
+    "totalShares": "0"
+  },
+  {
+    "feesSnapshot": "0",
+    "tokensList": [
+      "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+      "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+      "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+      "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+      "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+      "0x8505b9d2254a7ae468c0e9dd10ccea3a837aef5c",
+      "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+      "0xc2132d05d31c914a87c6611c10748aeb04b58e8f"
+    ],
+    "apr": {
+      "protocolApr": 0,
+      "min": 0,
+      "max": 0,
+      "rewardAprs": {
+        "total": 0,
+        "breakdown": {}
+      },
+      "stakingApr": {
+        "max": 0,
+        "min": 0
+      },
+      "swapFees": 0,
+      "tokenAprs": {
+        "total": 0,
+        "breakdown": {}
+      }
+    },
+    "holdersCount": "0",
+    "swapEnabled": true,
+    "symbol": "13WMATIC-13WBTC-13USDC-13LINK-13WETH-13COMP-13BAL-13USDT",
+    "poolType": "Weighted",
+    "volumeSnapshot": "0",
+    "address": "0xf506984c16737b1a9577cadeda02a49fd612aff8",
+    "lastUpdate": 1670946730300,
+    "name": "13WMATIC-13WBTC-13USDC-13LINK-13WETH-13COMP-13BAL-13USDT",
+    "totalWeight": "1",
+    "swapsCount": "0",
+    "totalSwapFee": "0",
+    "chainId": 137,
+    "totalLiquidity": "0",
+    "swapFee": "0.01",
+    "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152",
+    "tokens": [
+      {
+        "symbol": "WMATIC",
+        "address": "0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 18,
+        "name": "Wrapped Matic",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270",
+        "invested": "0"
+      },
+      {
+        "symbol": "WBTC",
+        "address": "0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 8,
+        "name": "(PoS) Wrapped BTC",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0x1bfd67037b42cf73acf2047067bd4f2c47d9bfd6",
+        "invested": "0"
+      },
+      {
+        "symbol": "USDC",
+        "address": "0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 6,
+        "name": "USD Coin (PoS)",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0x2791bca1f2de4661ed88a30c99a7a9449aa84174",
+        "invested": "0"
+      },
+      {
+        "symbol": "LINK",
+        "address": "0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 18,
+        "name": "ChainLink Token",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0x53e0bca35ec356bd5dddfebbd1fc0fd03fabad39",
+        "invested": "0"
+      },
+      {
+        "symbol": "WETH",
+        "address": "0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 18,
+        "name": "Wrapped Ether",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0x7ceb23fd6bc0add59e62ac25578270cff1b9f619",
+        "invested": "0"
+      },
+      {
+        "symbol": "COMP",
+        "address": "0x8505b9d2254a7ae468c0e9dd10ccea3a837aef5c",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 18,
+        "name": "(PoS) Compound",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0x8505b9d2254a7ae468c0e9dd10ccea3a837aef5c",
+        "invested": "0"
+      },
+      {
+        "symbol": "BAL",
+        "address": "0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 18,
+        "name": "Balancer (PoS)",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0x9a71012b13ca4d3d0cdc72a177df3ef03b0e76a3",
+        "invested": "0"
+      },
+      {
+        "symbol": "USDT",
+        "address": "0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        "priceRate": "1",
+        "balance": "0.0",
+        "decimals": 6,
+        "name": "(PoS) Tether USD",
+        "weight": "0.125",
+        "id": "0xf506984c16737b1a9577cadeda02a49fd612aff8000100000000000000000152-0xc2132d05d31c914a87c6611c10748aeb04b58e8f",
+        "invested": "0"
+      }
+    ],
+    "totalSwapVolume": "0",
+    "totalShares": "0"
   }
 ]


### PR DESCRIPTION
calculateLiquidity was throwing an error if a pool contains a sub-pool that has no shares (so hasn't been initialised yet). This fixes that error and adds a test for it with the pool that was crashing.

Fixes https://sentry.io/organizations/balancer-labs/issues/3864924851/