### PR TITLE
feat: missing native in token gecko fetch

### DIFF
--- a/balancer-js/src/modules/data/token-prices/coingecko.ts
+++ b/balancer-js/src/modules/data/token-prices/coingecko.ts
@@ -48,7 +48,9 @@ export class CoingeckoPriceRepository implements Findable<Price> {
       ETH = 'matic-network',
       MATIC = 'ethereum',
     }
-    const assetId = this.chainId === 137 ? 'matic-network' : 'ethereum';
+    let assetId = 'ethereum';
+    if (this.chainId === 137) assetId = 'matic-network';
+    if (this.chainId === 100) assetId = 'xdai';
     return axios
       .get<{ [key in Assets]: Price }>(
         `https://api.coingecko.com/api/v3/simple/price/?vs_currencies=eth,usd&ids=${assetId}`,

--- a/balancer-js/src/modules/data/token-prices/coingecko.ts
+++ b/balancer-js/src/modules/data/token-prices/coingecko.ts
@@ -49,9 +49,9 @@ export class CoingeckoPriceRepository implements Findable<Price> {
       MATIC = 'matic-network',
       XDAI = 'xdai',
     }
-    let assetId = 'ethereum';
-    if (this.chainId === 137) assetId = 'matic-network';
-    if (this.chainId === 100) assetId = 'xdai';
+    let assetId: Assets = Assets.ETH;
+    if (this.chainId === 137) assetId = Assets.MATIC;
+    if (this.chainId === 100) assetId = Assets.XDAI;
     return axios
       .get<{ [key in Assets]: Price }>(
         `https://api.coingecko.com/api/v3/simple/price/?vs_currencies=eth,usd&ids=${assetId}`,

--- a/balancer-js/src/modules/data/token-prices/coingecko.ts
+++ b/balancer-js/src/modules/data/token-prices/coingecko.ts
@@ -45,8 +45,9 @@ export class CoingeckoPriceRepository implements Findable<Price> {
   }: { signal?: AbortSignal } = {}): Promise<Price> {
     console.time(`fetching coingecko for native token`);
     enum Assets {
-      ETH = 'matic-network',
-      MATIC = 'ethereum',
+      ETH = 'ethereum',
+      MATIC = 'matic-network',
+      XDAI = 'xdai',
     }
     let assetId = 'ethereum';
     if (this.chainId === 137) assetId = 'matic-network';


### PR DESCRIPTION
We assume native asset is ETH unless network is Polygon. But this should also check for network Gnosis as native token is xDai.