### PR TITLE
Fix bug with volume snapshot and fees calculation

### DIFF
--- a/balancer-js/src/lib/utils/time.ts
+++ b/balancer-js/src/lib/utils/time.ts
@@ -1,4 +1,5 @@
 export const oneSecondInMs = 1000;
+export const twentyFourHoursInSecs = 24 * 60 * 60;
 
 export function toJsTimestamp(unixTimestamp: number): number {
   return unixTimestamp * oneSecondInMs;
@@ -6,4 +7,11 @@ export function toJsTimestamp(unixTimestamp: number): number {
 
 export function toUnixTimestamp(jsTimestamp: number): number {
   return Math.round(jsTimestamp / oneSecondInMs);
+}
+
+export function isLessThan24Hours(incomingDateInSec: number): boolean {
+  const now = Math.round(Date.now() / 1000);
+  const difference = now - incomingDateInSec;
+
+  return difference < twentyFourHoursInSecs;
 }

--- a/balancer-js/src/modules/pools/fees/fees.ts
+++ b/balancer-js/src/modules/pools/fees/fees.ts
@@ -3,6 +3,7 @@
  *
  * 1. Pool fees in last 24hrs
  */
+import { isLessThan24Hours } from '@/lib/utils/time';
 import { Pool, Findable, PoolAttribute } from '@/types';
 
 export class PoolFees {
@@ -20,9 +21,15 @@ export class PoolFees {
     if (!pool.totalSwapFee) {
       return 0;
     }
-    if (!yesterdaysPool || !yesterdaysPool.totalSwapFee) {
-      return parseFloat(pool.totalSwapFee);
+
+    if (!yesterdaysPool?.totalSwapFee) {
+      // Process edge case when pool creation time is less that 24h
+      if (pool.createTime && isLessThan24Hours(pool.createTime)) {
+        return parseFloat(pool.totalSwapFee);
+      }
+      return 0;
     }
+
     return (
       parseFloat(pool.totalSwapFee) - parseFloat(yesterdaysPool.totalSwapFee)
     );

--- a/balancer-js/src/modules/pools/volume/volume.ts
+++ b/balancer-js/src/modules/pools/volume/volume.ts
@@ -3,6 +3,7 @@
  *
  * 1. Pool fees in last 24hrs
  */
+import { isLessThan24Hours } from '@/lib/utils/time';
 import { Pool, Findable, PoolAttribute } from '@/types';
 
 export class PoolVolume {
@@ -18,7 +19,15 @@ export class PoolVolume {
       yesterdaysPool = await this.yesterdaysPools.find(pool.id);
     }
 
-    if (!pool.totalSwapVolume || !yesterdaysPool?.totalSwapVolume) {
+    if (!pool.totalSwapVolume) {
+      return 0;
+    }
+
+    if (!yesterdaysPool?.totalSwapVolume) {
+      // Process edge case when pool creation time is less that 24h
+      if (pool.createTime && isLessThan24Hours(pool.createTime)) {
+        return parseFloat(pool.totalSwapVolume);
+      }
       return 0;
     }
 

--- a/balancer-js/src/modules/pools/volume/volume.ts
+++ b/balancer-js/src/modules/pools/volume/volume.ts
@@ -18,12 +18,8 @@ export class PoolVolume {
       yesterdaysPool = await this.yesterdaysPools.find(pool.id);
     }
 
-    if (!pool.totalSwapVolume) {
+    if (!pool.totalSwapVolume || !yesterdaysPool?.totalSwapVolume) {
       return 0;
-    }
-
-    if (!yesterdaysPool || !yesterdaysPool.totalSwapVolume) {
-      return parseFloat(pool.totalSwapVolume);
     }
 
     return (


### PR DESCRIPTION
There are some pools with very high volume, but zero liquidity, e.g.
https://app.balancer.fi/#/ethereum/pool/0xa30ac4a3bf3f680a29eb02238280c75acbb89d6d0002000000000000000000d3
https://app.balancer.fi/#/ethereum/pool/0x4eebc19e5f29dec3dea07f66b9e707afc8f28c060002000000000000000000b3

It happens because the volume corresponds to the total volume, not the past 24h. This pr should fix this + the same problem with fees