### PR TITLE
Stable exit refactor

### DIFF
--- a/balancer-js/src/lib/constants/config.ts
+++ b/balancer-js/src/lib/constants/config.ts
@@ -3,6 +3,10 @@ import { BalancerNetworkConfig } from '@/types';
 
 export const balancerVault = '0xBA12222222228d8Ba445958a75a0704d566BF2C8';
 
+// Info fetched using npm package slot20
+export const BPT_SLOT = 0;
+export const BPT_DECIMALS = 18;
+
 export const BALANCER_NETWORK_CONFIG: Record<Network, BalancerNetworkConfig> = {
   [Network.MAINNET]: {
     chainId: Network.MAINNET, //1

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
@@ -38,7 +38,7 @@ describe('StablePool', async () => {
         [BPT_SLOT],
         [parseFixed(initialBalance, 18).toString()],
         jsonRpcUrl as string,
-        blockNumber // holds the same state as the static repository
+        blockNumber
       );
       const testPool = new TestPoolHelper(
         testPoolId,

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
@@ -1,7 +1,7 @@
 // yarn test:only ./src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
 import dotenv from 'dotenv';
 import { expect } from 'chai';
-import { Network, PoolWithMethods } from '@/.';
+import { insert, Network, PoolWithMethods } from '@/.';
 import hardhat from 'hardhat';
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import {
@@ -22,15 +22,16 @@ const network = Network.MAINNET;
 const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
 const signer = provider.getSigner();
 
-describe('exit stable pools execution', async () => {
+describe('StablePool', async () => {
   let signerAddress: string;
   let pool: PoolWithMethods;
   const initialBalance = '100000';
-  const blockNumber = 14717479;
+  // This blockNumber is before protocol fees were switched on (Oct `21), for blockNos after this tests will fail because results don't 100% match
+  const blockNumber = 13309758;
   const testPoolId =
     '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063';
   // Setup chain
-  context('exitExactBPTIn', async () => {
+  context('exit pool functions', async () => {
     beforeEach(async function () {
       await forkSetup(
         signer,
@@ -50,183 +51,151 @@ describe('exit stable pools execution', async () => {
       pool = await testPool.getPool();
       signerAddress = await signer.getAddress();
     });
-    it('should work with single token maxed out', async () => {
-      const bptIn = parseFixed('10', BPT_DECIMALS).toString();
-      const slippage = '10';
-      const { to, data, minAmountsOut, expectedAmountsOut } =
-        pool.buildExitExactBPTIn(
-          signerAddress,
-          bptIn,
-          slippage,
-          false,
-          pool.tokensList[0]
+    context('buildExitExactBPTIn', async () => {
+      it('should work with single token maxed out', async () => {
+        const bptIn = parseFixed('10', BPT_DECIMALS).toString();
+        const slippage = '0';
+        const { to, data, minAmountsOut, expectedAmountsOut } =
+          pool.buildExitExactBPTIn(
+            signerAddress,
+            bptIn,
+            slippage,
+            false,
+            pool.tokensList[0]
+          );
+        const { transactionReceipt, balanceDeltas } =
+          await sendTransactionGetBalances(
+            [pool.address, ...pool.tokensList],
+            signer,
+            signerAddress,
+            to,
+            data
+          );
+        expect(transactionReceipt.status).to.eq(1);
+        const expectedDeltas = insert(expectedAmountsOut, 0, bptIn);
+        expect(expectedDeltas).to.deep.eq(
+          balanceDeltas.map((a) => a.toString())
         );
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          [pool.address, ...pool.tokensList],
-          signer,
-          signerAddress,
-          to,
-          data
+        const expectedMins = expectedAmountsOut.map((a) =>
+          subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
         );
-      expect(transactionReceipt.status).to.eql(1);
-      expect(bptIn).to.be.eq(balanceDeltas[0].toString());
-      minAmountsOut.forEach((minAmount, index) => {
-        expect(BigInt(minAmount) <= BigInt(balanceDeltas[index + 1].toString()))
-          .to.be.true;
+        expect(expectedMins).to.deep.eq(minAmountsOut);
       });
-      const expectedMins = expectedAmountsOut.map((a) =>
-        subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
-      );
-      expect(expectedMins).to.deep.eq(minAmountsOut);
-    });
-    it('should work with proportional amounts out', async () => {
-      const bptIn = parseFixed('1', BPT_DECIMALS).toString();
-      const slippage = '10';
-      const { to, data, minAmountsOut, expectedAmountsOut } =
-        pool.buildExitExactBPTIn(signerAddress, bptIn, slippage);
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          [pool.address, ...pool.tokensList],
-          signer,
-          signerAddress,
-          to,
-          data
+      it('should work with proportional amounts out', async () => {
+        const bptIn = parseFixed('1', BPT_DECIMALS).toString();
+        const slippage = '0';
+        const { to, data, minAmountsOut, expectedAmountsOut } =
+          pool.buildExitExactBPTIn(signerAddress, bptIn, slippage);
+        const { transactionReceipt, balanceDeltas } =
+          await sendTransactionGetBalances(
+            [pool.address, ...pool.tokensList],
+            signer,
+            signerAddress,
+            to,
+            data
+          );
+        expect(transactionReceipt.status).to.eq(1);
+        const expectedDeltas = insert(expectedAmountsOut, 0, bptIn);
+        expect(expectedDeltas).to.deep.eq(
+          balanceDeltas.map((a) => a.toString())
         );
-      const expectedMins = expectedAmountsOut.map((a) =>
-        subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
-      );
-      expect(expectedMins).to.deep.eq(minAmountsOut);
-      expect(transactionReceipt.status).to.eql(1);
-      expect(bptIn).to.be.eq(balanceDeltas[0].toString());
-      minAmountsOut.forEach((minAmount, index) => {
-        expect(BigInt(minAmount) <= BigInt(balanceDeltas[index + 1].toString()))
-          .to.be.true;
+        const expectedMins = expectedAmountsOut.map((a) =>
+          subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
+        );
+        expect(expectedMins).to.deep.eq(minAmountsOut);
       });
     });
-  });
 
-  context('exitExactTokensOut', async () => {
-    beforeEach(async function () {
-      await forkSetup(
-        signer,
-        [testPoolId.slice(0, 42)],
-        [BPT_SLOT],
-        [parseFixed(initialBalance, 18).toString()],
-        jsonRpcUrl as string,
-        blockNumber // holds the same state as the static repository
-      );
-      const testPool = new TestPoolHelper(
-        testPoolId,
-        network,
-        rpcUrl,
-        blockNumber
-      );
-      //updated pool, getting the pool info from the reseted fork with forkSetup
-      pool = await testPool.getPool();
-      signerAddress = await signer.getAddress();
-    });
-    // Setup chain
-    beforeEach(async function () {
-      const testPool = new TestPoolHelper(
-        testPoolId,
-        network,
-        rpcUrl,
-        blockNumber
-      );
-      pool = await testPool.getPool();
-      await forkSetup(
-        signer,
-        [pool.address],
-        [BPT_SLOT],
-        [parseFixed(initialBalance, 18).toString()],
-        jsonRpcUrl as string,
-        14717479 // holds the same state as the static repository
-      );
-      signerAddress = await signer.getAddress();
-    });
-    it('should work with all tokens out', async () => {
-      const tokensOut = pool.tokensList;
-      const amountsOut = pool.tokens.map((t, i) =>
-        parseFixed((i * 100).toString(), t.decimals).toString()
-      );
-      const slippage = '10';
-      const { to, data, maxBPTIn, expectedBPTIn } =
-        pool.buildExitExactTokensOut(
+    context('buildExitExactTokensOut', async () => {
+      it('all tokens with value', async () => {
+        const tokensOut = pool.tokensList;
+        const amountsOut = pool.tokens.map((t, i) =>
+          parseFixed((i * 100).toString(), t.decimals).toString()
+        );
+        const slippage = '0';
+        const { to, data, maxBPTIn, expectedBPTIn } =
+          pool.buildExitExactTokensOut(
+            signerAddress,
+            tokensOut,
+            amountsOut,
+            slippage
+          );
+        const { transactionReceipt, balanceDeltas } =
+          await sendTransactionGetBalances(
+            [pool.address, ...pool.tokensList],
+            signer,
+            signerAddress,
+            to,
+            data
+          );
+        expect(transactionReceipt.status).to.eq(1);
+        const expectedDeltas = insert(amountsOut, 0, expectedBPTIn);
+        expect(expectedDeltas).to.deep.eq(
+          balanceDeltas.map((a) => a.toString())
+        );
+        const expectedMaxBpt = addSlippage(
+          BigNumber.from(expectedBPTIn),
+          BigNumber.from(slippage)
+        ).toString();
+        expect(expectedMaxBpt).to.deep.eq(maxBPTIn);
+      });
+      it('single token with value', async () => {
+        const tokensOut = pool.tokensList;
+        const amountsOut = pool.tokens.map((t, i) => {
+          if (i === 0) {
+            return parseFixed('100', t.decimals).toString();
+          }
+          return '0';
+        });
+        const slippage = '0';
+        const { to, data, maxBPTIn, expectedBPTIn } =
+          pool.buildExitExactTokensOut(
+            signerAddress,
+            tokensOut,
+            amountsOut,
+            slippage
+          );
+        const { transactionReceipt, balanceDeltas } =
+          await sendTransactionGetBalances(
+            [pool.address, ...pool.tokensList],
+            signer,
+            signerAddress,
+            to,
+            data
+          );
+        expect(transactionReceipt.status).to.eq(1);
+        const expectedDeltas = insert(amountsOut, 0, expectedBPTIn);
+        expect(expectedDeltas).to.deep.eq(
+          balanceDeltas.map((a) => a.toString())
+        );
+        const expectedMaxBpt = addSlippage(
+          BigNumber.from(expectedBPTIn),
+          BigNumber.from(slippage)
+        ).toString();
+        expect(expectedMaxBpt).to.deep.eq(maxBPTIn);
+      });
+      it('should automatically sort tokens/amounts in correct order', async () => {
+        const tokensOut = pool.tokensList;
+        const amountsOut = pool.tokens.map((t, i) =>
+          parseFixed((i * 100).toString(), t.decimals).toString()
+        );
+        const slippage = '10';
+        // TokensIn are already ordered as required by vault
+        const attributesA = pool.buildExitExactTokensOut(
           signerAddress,
           tokensOut,
           amountsOut,
           slippage
         );
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          [pool.address, ...pool.tokensList],
-          signer,
+        // TokensIn are not ordered as required by vault and will be sorted correctly
+        const attributesB = pool.buildExitExactTokensOut(
           signerAddress,
-          to,
-          data
+          tokensOut.reverse(),
+          amountsOut.reverse(),
+          slippage
         );
-      expect(transactionReceipt.status).to.eql(1);
-      expect(BigInt(maxBPTIn) >= balanceDeltas[0].toBigInt()).to.be.true;
-      expect(amountsOut).to.deep.eq(
-        balanceDeltas.slice(1).map((a) => a.toString())
-      );
-      const expectedMaxBPTIn = addSlippage(
-        BigNumber.from(expectedBPTIn),
-        BigNumber.from(slippage)
-      ).toString();
-      expect(expectedMaxBPTIn).to.deep.eq(maxBPTIn);
-    });
-    it('should work for a single token out', async () => {
-      const tokensOut = pool.tokensList;
-      const amountsOut = pool.tokens.map((t, i) => {
-        if (i === 0) {
-          return parseFixed('100', t.decimals).toString();
-        }
-        return '0';
+        expect(attributesA).to.deep.eq(attributesB);
       });
-      const slippage = '1';
-      const { to, data, maxBPTIn } = pool.buildExitExactTokensOut(
-        signerAddress,
-        tokensOut,
-        amountsOut,
-        slippage
-      );
-      const { transactionReceipt, balanceDeltas } =
-        await sendTransactionGetBalances(
-          [pool.address, ...pool.tokensList],
-          signer,
-          signerAddress,
-          to,
-          data
-        );
-      expect(transactionReceipt.status).to.eql(1);
-      expect(BigInt(maxBPTIn) >= balanceDeltas[0].toBigInt()).to.be.true;
-      expect(amountsOut).to.deep.eq(
-        balanceDeltas.slice(1).map((a) => a.toString())
-      );
-    });
-    it('should automatically sort tokens/amounts in correct order', async () => {
-      const tokensOut = pool.tokensList;
-      const amountsOut = pool.tokens.map((t, i) =>
-        parseFixed((i * 100).toString(), t.decimals).toString()
-      );
-      const slippage = '10';
-      // TokensIn are already ordered as required by vault
-      const attributesA = pool.buildExitExactTokensOut(
-        signerAddress,
-        tokensOut,
-        amountsOut,
-        slippage
-      );
-      // TokensIn are not ordered as required by vault and will be sorted correctly
-      const attributesB = pool.buildExitExactTokensOut(
-        signerAddress,
-        tokensOut.reverse(),
-        amountsOut.reverse(),
-        slippage
-      );
-      expect(attributesA).to.deep.eq(attributesB);
     });
   });
 });

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
@@ -1,15 +1,16 @@
 // yarn test:only ./src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
 import dotenv from 'dotenv';
 import { expect } from 'chai';
-import { BalancerSDK, Network, Pool } from '@/.';
+import { Network, PoolWithMethods } from '@/.';
 import hardhat from 'hardhat';
-
-import { TransactionReceipt } from '@ethersproject/providers';
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
-import { forkSetup, getBalances } from '@/test/lib/utils';
-import { Pools } from '@/modules/pools';
-
-import pools_14717479 from '@/test/lib/pools_14717479.json';
+import {
+  forkSetup,
+  sendTransactionGetBalances,
+  TestPoolHelper,
+} from '@/test/lib/utils';
+import { BPT_DECIMALS, BPT_SLOT } from '@/lib/constants/config';
+import { addSlippage, subSlippage } from '@/lib/utils/slippageHelper';
 
 dotenv.config();
 
@@ -18,238 +19,208 @@ const { ethers } = hardhat;
 
 const rpcUrl = 'http://127.0.0.1:8545';
 const network = Network.MAINNET;
-const { networkConfig } = new BalancerSDK({ network, rpcUrl });
-const wrappedNativeAsset =
-  networkConfig.addresses.tokens.wrappedNativeAsset.toLowerCase();
-
 const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
 const signer = provider.getSigner();
 
-// Slots used to set the account balance for each token through hardhat_setStorageAt
-// Info fetched using npm package slot20
-const BPT_SLOT = 0;
-const initialBalance = '100000';
-const amountsOutDiv = (1e7).toString(); // FIXME: depending on this number, exitExactTokenOut (single token) throws Errors.STABLE_INVARIANT_DIDNT_CONVERGE
-const slippage = '100';
-
-const pool = pools_14717479.find(
-  (pool) =>
-    pool.id ==
-    '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063' // Balancer USD Stable Pool - staBAL3
-) as unknown as Pool;
-const tokensOut = pool.tokens;
-const controller = Pools.wrap(pool, networkConfig);
-
 describe('exit stable pools execution', async () => {
-  let amountsOut: string[];
-  let transactionReceipt: TransactionReceipt;
-  let bptBalanceBefore: BigNumber;
-  let bptBalanceAfter: BigNumber;
-  let bptMaxBalanceDecrease: BigNumber;
-  let tokensBalanceBefore: BigNumber[];
-  let tokensBalanceAfter: BigNumber[];
-  let tokensMinBalanceIncrease: BigNumber[];
-  let transactionCost: BigNumber;
   let signerAddress: string;
-
+  let pool: PoolWithMethods;
+  const initialBalance = '100000';
+  const blockNumber = 14717479;
+  const testPoolId =
+    '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063';
   // Setup chain
-  before(async function () {
-    await forkSetup(
-      signer,
-      [pool.address],
-      [BPT_SLOT],
-      [parseFixed(initialBalance, 18).toString()],
-      jsonRpcUrl as string,
-      14717479 // holds the same state as the static repository
-    );
-    signerAddress = await signer.getAddress();
-  });
-
-  const testFlow = async (
-    [to, data, maxBPTIn, minAmountsOut]: [string, string, string, string[]],
-    exitTokens: string[],
-    exitWithETH = false
-  ) => {
-    // Check balances before transaction to confirm success
-    [bptBalanceBefore, ...tokensBalanceBefore] = await getBalances(
-      [pool.address, ...exitTokens],
-      signer,
-      signerAddress
-    );
-
-    // Get expected balances out of transaction
-    bptMaxBalanceDecrease = BigNumber.from(maxBPTIn);
-    tokensMinBalanceIncrease = minAmountsOut.map((a) => BigNumber.from(a));
-
-    // Send transaction to local fork
-    const transactionResponse = await signer.sendTransaction({ to, data });
-    transactionReceipt = await transactionResponse.wait();
-
-    // Check balances after transaction to confirm success
-    [bptBalanceAfter, ...tokensBalanceAfter] = await getBalances(
-      [pool.address, ...exitTokens],
-      signer,
-      signerAddress
-    );
-
-    // add transaction cost to ETH balance when exiting with ETH
-    if (exitWithETH) {
-      transactionCost = transactionReceipt.gasUsed.mul(
-        transactionReceipt.effectiveGasPrice
-      );
-      tokensBalanceAfter = tokensBalanceAfter.map((balance, i) => {
-        if (pool.tokensList[i] === wrappedNativeAsset) {
-          return balance.add(transactionCost);
-        }
-        return balance;
-      });
-    }
-  };
-
   context('exitExactBPTIn', async () => {
-    context('proportional amounts out', async () => {
-      before(async function () {
-        const bptIn = parseFixed('10', 18).toString();
-        const { to, data, minAmountsOut } = controller.buildExitExactBPTIn(
-          signerAddress,
-          bptIn,
-          slippage
-        );
-        await testFlow([to, data, bptIn, minAmountsOut], pool.tokensList);
-      });
-
-      it('should work', async () => {
-        expect(transactionReceipt.status).to.eql(1);
-      });
-
-      it('tokens balance should increase by at least minAmountsOut', async () => {
-        for (let i = 0; i < tokensBalanceAfter.length; i++) {
-          expect(
-            tokensBalanceAfter[i]
-              .sub(tokensBalanceBefore[i])
-              .gte(tokensMinBalanceIncrease[i])
-          ).to.be.true;
-        }
-      });
-
-      it('bpt balance should decrease by exact bptMaxBalanceDecrease', async () => {
-        expect(bptBalanceBefore.sub(bptBalanceAfter).eq(bptMaxBalanceDecrease))
-          .to.be.true;
-      });
+    beforeEach(async function () {
+      await forkSetup(
+        signer,
+        [testPoolId.slice(0, 42)],
+        [BPT_SLOT],
+        [parseFixed(initialBalance, 18).toString()],
+        jsonRpcUrl as string,
+        blockNumber // holds the same state as the static repository
+      );
+      const testPool = new TestPoolHelper(
+        testPoolId,
+        network,
+        rpcUrl,
+        blockNumber
+      );
+      //updated pool, getting the pool info from the reseted fork with forkSetup
+      pool = await testPool.getPool();
+      signerAddress = await signer.getAddress();
     });
-    context('single token max out', async () => {
-      before(async function () {
-        const bptIn = parseFixed('10', 18).toString();
-        const { to, data, minAmountsOut } = controller.buildExitExactBPTIn(
+    it('should work with single token maxed out', async () => {
+      const bptIn = parseFixed('10', BPT_DECIMALS).toString();
+      const slippage = '100';
+      const { to, data, minAmountsOut, expectedAmountsOut } =
+        pool.buildExitExactBPTIn(
           signerAddress,
           bptIn,
           slippage,
           false,
           pool.tokensList[0]
         );
-        await testFlow([to, data, bptIn, minAmountsOut], pool.tokensList);
-      });
-
-      it('should work', async () => {
-        expect(transactionReceipt.status).to.eql(1);
-      });
-
-      it('tokens balance should increase by at least minAmountsOut', async () => {
-        for (let i = 0; i < tokensBalanceAfter.length; i++) {
-          expect(
-            tokensBalanceAfter[i]
-              .sub(tokensBalanceBefore[i])
-              .gte(tokensMinBalanceIncrease[i])
-          ).to.be.true;
-        }
-      });
-
-      it('bpt balance should decrease by exact bptMaxBalanceDecrease', async () => {
-        expect(bptBalanceBefore.sub(bptBalanceAfter).eq(bptMaxBalanceDecrease))
-          .to.be.true;
-      });
+      const { transactionReceipt, balanceDeltas } =
+        await sendTransactionGetBalances(
+          [pool.address, ...pool.tokensList],
+          signer,
+          signerAddress,
+          to,
+          data
+        );
+      expect(transactionReceipt.status).to.eql(1);
+      expect([bptIn, ...expectedAmountsOut]).to.deep.eq(
+        balanceDeltas.map((a) => a.toString())
+      );
+      const expectedMins = expectedAmountsOut.map((a) =>
+        subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
+      );
+      expect(expectedMins).to.deep.eq(minAmountsOut);
+    });
+    it('should work with proportional amounts out', async () => {
+      const bptIn = parseFixed('1', BPT_DECIMALS).toString();
+      const slippage = '0';
+      const { to, data, minAmountsOut, expectedAmountsOut } =
+        pool.buildExitExactBPTIn(signerAddress, bptIn, slippage);
+      const { transactionReceipt, balanceDeltas } =
+        await sendTransactionGetBalances(
+          [pool.address, ...pool.tokensList],
+          signer,
+          signerAddress,
+          to,
+          data
+        );
+      const expectedMins = expectedAmountsOut.map((a) =>
+        subSlippage(BigNumber.from(a), BigNumber.from(slippage)).toString()
+      );
+      expect(expectedMins).to.deep.eq(minAmountsOut);
+      expect(transactionReceipt.status).to.eql(1);
+      expect([bptIn, ...expectedAmountsOut]).to.deep.eq(
+        balanceDeltas.map((a) => a.toString())
+      );
     });
   });
 
   context('exitExactTokensOut', async () => {
-    context('all tokens out', async () => {
-      before(async function () {
-        amountsOut = pool.tokens.map((t, i) =>
-          parseFixed(t.balance, t.decimals)
-            .div(amountsOutDiv)
-            .mul(i + 1)
-            .toString()
-        );
-
-        const { to, data, maxBPTIn } = controller.buildExitExactTokensOut(
-          signerAddress,
-          tokensOut.map((t) => t.address),
-          amountsOut,
-          slippage
-        );
-
-        await testFlow([to, data, maxBPTIn, amountsOut], pool.tokensList);
-      });
-
-      it('should work', async () => {
-        expect(transactionReceipt.status).to.eql(1);
-      });
-
-      it('tokens balance should increase by exact amountsOut', async () => {
-        for (let i = 0; i < tokensBalanceAfter.length; i++) {
-          expect(
-            tokensBalanceAfter[i]
-              .sub(tokensBalanceBefore[i])
-              .eq(tokensMinBalanceIncrease[i])
-          ).to.be.true;
-        }
-      });
-
-      it('bpt balance should decrease by max bptMaxBalanceDecrease', async () => {
-        expect(bptBalanceBefore.sub(bptBalanceAfter).lte(bptMaxBalanceDecrease))
-          .to.be.true;
-      });
+    beforeEach(async function () {
+      await forkSetup(
+        signer,
+        [testPoolId.slice(0, 42)],
+        [BPT_SLOT],
+        [parseFixed(initialBalance, 18).toString()],
+        jsonRpcUrl as string,
+        blockNumber // holds the same state as the static repository
+      );
+      const testPool = new TestPoolHelper(
+        testPoolId,
+        network,
+        rpcUrl,
+        blockNumber
+      );
+      //updated pool, getting the pool info from the reseted fork with forkSetup
+      pool = await testPool.getPool();
+      signerAddress = await signer.getAddress();
     });
-
-    context('single token out', async () => {
-      before(async function () {
-        amountsOut = pool.tokens.map((t, i) => {
-          if (i === 0) {
-            return parseFixed(t.balance, t.decimals)
-              .div(amountsOutDiv)
-              .toString();
-          }
-          return '0';
-        });
-
-        const { to, data, maxBPTIn } = controller.buildExitExactTokensOut(
+    // Setup chain
+    beforeEach(async function () {
+      const testPool = new TestPoolHelper(
+        testPoolId,
+        network,
+        rpcUrl,
+        blockNumber
+      );
+      pool = await testPool.getPool();
+      await forkSetup(
+        signer,
+        [pool.address],
+        [BPT_SLOT],
+        [parseFixed(initialBalance, 18).toString()],
+        jsonRpcUrl as string,
+        14717479 // holds the same state as the static repository
+      );
+      signerAddress = await signer.getAddress();
+    });
+    it('should work with all tokens out', async () => {
+      const tokensOut = pool.tokensList;
+      const amountsOut = pool.tokens.map((t, i) =>
+        parseFixed((i * 100).toString(), t.decimals).toString()
+      );
+      const slippage = '1';
+      const { to, data, maxBPTIn, expectedBPTIn } =
+        pool.buildExitExactTokensOut(
           signerAddress,
-          tokensOut.map((t) => t.address),
+          tokensOut,
           amountsOut,
           slippage
         );
-
-        await testFlow([to, data, maxBPTIn, amountsOut], pool.tokensList);
-      });
-
-      it('should work', async () => {
-        expect(transactionReceipt.status).to.eql(1);
-      });
-
-      it('tokens balance should increase by exact amountsOut', async () => {
-        for (let i = 0; i < tokensBalanceAfter.length; i++) {
-          expect(
-            tokensBalanceAfter[i]
-              .sub(tokensBalanceBefore[i])
-              .eq(tokensMinBalanceIncrease[i])
-          ).to.be.true;
+      const { transactionReceipt, balanceDeltas } =
+        await sendTransactionGetBalances(
+          [pool.address, ...pool.tokensList],
+          signer,
+          signerAddress,
+          to,
+          data
+        );
+      expect(transactionReceipt.status).to.eql(1);
+      expect([expectedBPTIn, ...amountsOut]).to.deep.eq(
+        balanceDeltas.map((a) => a.toString())
+      );
+      const expectedMaxBPTIn = addSlippage(
+        BigNumber.from(expectedBPTIn),
+        BigNumber.from(slippage)
+      ).toString();
+      expect(expectedMaxBPTIn).to.deep.eq(maxBPTIn);
+    });
+    it('should work for a single token out', async () => {
+      const tokensOut = pool.tokensList;
+      const amountsOut = pool.tokens.map((t, i) => {
+        if (i === 0) {
+          return parseFixed('100', t.decimals).toString();
         }
+        return '0';
       });
-
-      it('bpt balance should decrease by max bptMaxBalanceDecrease', async () => {
-        expect(bptBalanceBefore.sub(bptBalanceAfter).lte(bptMaxBalanceDecrease))
-          .to.be.true;
-      });
+      const slippage = '1';
+      const { to, data, expectedBPTIn } = pool.buildExitExactTokensOut(
+        signerAddress,
+        tokensOut,
+        amountsOut,
+        slippage
+      );
+      const { transactionReceipt, balanceDeltas } =
+        await sendTransactionGetBalances(
+          [pool.address, ...pool.tokensList],
+          signer,
+          signerAddress,
+          to,
+          data
+        );
+      expect(transactionReceipt.status).to.eql(1);
+      expect([expectedBPTIn, ...amountsOut]).to.deep.eq(
+        balanceDeltas.map((a) => a.toString())
+      );
+    });
+    it('should automatically sort tokens/amounts in correct order', async () => {
+      const tokensOut = pool.tokensList;
+      const amountsOut = pool.tokens.map((t, i) =>
+        parseFixed((i * 100).toString(), t.decimals).toString()
+      );
+      const slippage = '10';
+      // TokensIn are already ordered as required by vault
+      const attributesA = pool.buildExitExactTokensOut(
+        signerAddress,
+        tokensOut,
+        amountsOut,
+        slippage
+      );
+      // TokensIn are not ordered as required by vault and will be sorted correctly
+      const attributesB = pool.buildExitExactTokensOut(
+        signerAddress,
+        tokensOut.reverse(),
+        amountsOut.reverse(),
+        slippage
+      );
+      expect(attributesA).to.deep.eq(attributesB);
     });
   });
 });

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
@@ -1,22 +1,21 @@
 // yarn test:only ./src/modules/pools/pool-types/concerns/stable/exit.concern.integration.spec.ts
+import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import dotenv from 'dotenv';
 import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
 import { insert, Network, PoolWithMethods } from '@/.';
-import hardhat from 'hardhat';
-import { BigNumber, parseFixed } from '@ethersproject/bignumber';
+import { BPT_DECIMALS, BPT_SLOT } from '@/lib/constants/config';
+import { addSlippage, subSlippage } from '@/lib/utils/slippageHelper';
 import {
   forkSetup,
   sendTransactionGetBalances,
   TestPoolHelper,
 } from '@/test/lib/utils';
-import { BPT_DECIMALS, BPT_SLOT } from '@/lib/constants/config';
-import { addSlippage, subSlippage } from '@/lib/utils/slippageHelper';
 
 dotenv.config();
 
 const { ALCHEMY_URL: jsonRpcUrl } = process.env;
-const { ethers } = hardhat;
-
 const rpcUrl = 'http://127.0.0.1:8545';
 const network = Network.MAINNET;
 const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
@@ -173,28 +172,6 @@ describe('StablePool', async () => {
           BigNumber.from(slippage)
         ).toString();
         expect(expectedMaxBpt).to.deep.eq(maxBPTIn);
-      });
-      it('should automatically sort tokens/amounts in correct order', async () => {
-        const tokensOut = pool.tokensList;
-        const amountsOut = pool.tokens.map((t, i) =>
-          parseFixed((i * 100).toString(), t.decimals).toString()
-        );
-        const slippage = '10';
-        // TokensIn are already ordered as required by vault
-        const attributesA = pool.buildExitExactTokensOut(
-          signerAddress,
-          tokensOut,
-          amountsOut,
-          slippage
-        );
-        // TokensIn are not ordered as required by vault and will be sorted correctly
-        const attributesB = pool.buildExitExactTokensOut(
-          signerAddress,
-          tokensOut.reverse(),
-          amountsOut.reverse(),
-          slippage
-        );
-        expect(attributesA).to.deep.eq(attributesB);
       });
     });
   });

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
@@ -1,6 +1,5 @@
 import { parseFixed } from '@ethersproject/bignumber';
 import { expect } from 'chai';
-import { ethers } from 'hardhat';
 
 import { Network, PoolWithMethods } from '@/.';
 import { TestPoolHelper } from '@/test/lib/utils';
@@ -8,18 +7,15 @@ import { AddressZero } from '@ethersproject/constants';
 
 const rpcUrl = '';
 const network = Network.MAINNET;
-const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
-const signer = provider.getSigner();
 // This blockNumber is before protocol fees were switched on (Oct `21), for blockNos after this tests will fail because results don't 100% match
 const blockNumber = 13309758;
 const testPoolId =
   '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063';
 
 describe('StablePool exits', () => {
-  let signerAddress: string;
   let pool: PoolWithMethods;
+  const signerAddress = AddressZero;
   beforeEach(async function () {
-    signerAddress = await signer.getAddress();
     const testPoolHelper = new TestPoolHelper(
       testPoolId,
       network,
@@ -27,7 +23,6 @@ describe('StablePool exits', () => {
       blockNumber
     );
     pool = await testPoolHelper.getPool();
-    signerAddress = await signer.getAddress();
   });
 
   it('should fail due to conflicting inputs', () => {

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
@@ -5,7 +5,7 @@ import { Network, PoolWithMethods } from '@/.';
 import { TestPoolHelper } from '@/test/lib/utils';
 import { AddressZero } from '@ethersproject/constants';
 
-const rpcUrl = '';
+const rpcUrl = 'http://127.0.0.1:8545';
 const network = Network.MAINNET;
 // This blockNumber is before protocol fees were switched on (Oct `21), for blockNos after this tests will fail because results don't 100% match
 const blockNumber = 13309758;

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
@@ -1,47 +1,74 @@
-import { expect } from 'chai';
 import { parseFixed } from '@ethersproject/bignumber';
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+
+import { Network, PoolWithMethods } from '@/.';
+import { TestPoolHelper } from '@/test/lib/utils';
 import { AddressZero } from '@ethersproject/constants';
-
-import { BalancerSDK, Network, Pool } from '@/.';
-import pools_14717479 from '@/test/lib/pools_14717479.json';
-import { StablePoolExit } from './exit.concern';
-
-const stablePoolExit = new StablePoolExit();
 
 const rpcUrl = '';
 const network = Network.MAINNET;
-const { networkConfig } = new BalancerSDK({ network, rpcUrl });
-const wrappedNativeAsset =
-  networkConfig.addresses.tokens.wrappedNativeAsset.toLowerCase();
-
-const pool = pools_14717479.find(
-  (pool) =>
-    pool.id ==
-    '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063' // Balancer USD Stable Pool - staBAL3
-) as unknown as Pool;
+const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
+const signer = provider.getSigner();
+// This blockNumber is before protocol fees were switched on (Oct `21), for blockNos after this tests will fail because results don't 100% match
+const blockNumber = 13309758;
+const testPoolId =
+  '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063';
 
 describe('exit module', () => {
-  describe('buildExitExactBPTIn', () => {
-    context('exit with ETH', () => {
-      it('should fail due to conflicting inputs', () => {
-        let errorMessage = '';
-        try {
-          stablePoolExit.buildExitExactBPTIn({
-            exiter: '0x35f5a330FD2F8e521ebd259FA272bA8069590741',
-            pool,
-            bptIn: parseFixed('10', 18).toString(),
-            slippage: '100', // 100 bps
-            shouldUnwrapNativeAsset: false,
-            wrappedNativeAsset,
-            singleTokenMaxOut: AddressZero,
-          });
-        } catch (error) {
-          errorMessage = (error as Error).message;
-        }
-        expect(errorMessage).to.eql(
-          'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
-        );
-      });
-    });
+  let signerAddress: string;
+  let pool: PoolWithMethods;
+  beforeEach(async function () {
+    signerAddress = await signer.getAddress();
+    const testPoolHelper = new TestPoolHelper(
+      testPoolId,
+      network,
+      rpcUrl,
+      blockNumber
+    );
+    pool = await testPoolHelper.getPool();
+    signerAddress = await signer.getAddress();
+  });
+
+  it('should fail due to conflicting inputs', () => {
+    let errorMessage = '';
+    const bptIn = parseFixed('10', 18).toString();
+    const slippage = '100';
+    try {
+      pool.buildExitExactBPTIn(
+        signerAddress,
+        bptIn,
+        slippage,
+        false,
+        AddressZero
+      );
+    } catch (error) {
+      errorMessage = (error as Error).message;
+    }
+    expect(errorMessage).to.eql(
+      'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
+    );
+  });
+  it('should automatically sort tokens/amounts in correct order', async () => {
+    const tokensOut = pool.tokensList;
+    const amountsOut = pool.tokens.map((t, i) =>
+      parseFixed((i * 100).toString(), t.decimals).toString()
+    );
+    const slippage = '10';
+    // TokensIn are already ordered as required by vault
+    const attributesA = pool.buildExitExactTokensOut(
+      signerAddress,
+      tokensOut,
+      amountsOut,
+      slippage
+    );
+    // TokensIn are not ordered as required by vault and will be sorted correctly
+    const attributesB = pool.buildExitExactTokensOut(
+      signerAddress,
+      tokensOut.reverse(),
+      amountsOut.reverse(),
+      slippage
+    );
+    expect(attributesA).to.deep.eq(attributesB);
   });
 });

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.spec.ts
@@ -15,7 +15,7 @@ const blockNumber = 13309758;
 const testPoolId =
   '0x06df3b2bbb68adc8b0e302443692037ed9f91b42000000000000000000000063';
 
-describe('exit module', () => {
+describe('StablePool exits', () => {
   let signerAddress: string;
   let pool: PoolWithMethods;
   beforeEach(async function () {

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.ts
@@ -8,6 +8,7 @@ import {
   ExitExactBPTInParameters,
   ExitExactTokensOutParameters,
   ExitPool,
+  ExitPoolAttributes,
 } from '../types';
 import { AssetHelpers, isSameAddress, parsePoolInfo } from '@/lib/utils';
 import { Vault__factory } from '@balancer-labs/typechain';
@@ -16,6 +17,23 @@ import { balancerVault } from '@/lib/constants/config';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
 import { StablePoolEncoder } from '@/pool-stable';
 import { _downscaleDownArray, _upscaleArray } from '@/lib/utils/solidityMaths';
+
+type ExactBPTInSortedValues = {
+  parsedTokens: string[];
+  parsedAmp: string;
+  parsedTotalShares: string;
+  parsedSwapFee: string;
+  upScaledBalances: string[];
+  scalingFactors: bigint[];
+  singleTokenMaxOutIndex: number;
+};
+
+type EncodeExitParams = Pick<ExitExactBPTInParameters, 'exiter'> & {
+  poolTokens: string[];
+  poolId: string;
+  userData: string;
+  minAmountsOut: string[];
+};
 
 export class StablePoolExit implements ExitConcern {
   buildExitExactBPTIn = ({
@@ -27,144 +45,47 @@ export class StablePoolExit implements ExitConcern {
     wrappedNativeAsset,
     singleTokenMaxOut,
   }: ExitExactBPTInParameters): ExitExactBPTInAttributes => {
-    if (!bptIn.length || parseFixed(bptIn, 18).isNegative()) {
-      throw new BalancerError(BalancerErrorCode.INPUT_OUT_OF_BOUNDS);
-    }
-    if (
-      singleTokenMaxOut &&
-      singleTokenMaxOut !== AddressZero &&
-      !pool.tokens
-        .map((t) => t.address)
-        .some((a) => isSameAddress(a, singleTokenMaxOut))
-    ) {
-      throw new BalancerError(BalancerErrorCode.TOKEN_MISMATCH);
-    }
-
-    if (!shouldUnwrapNativeAsset && singleTokenMaxOut === AddressZero)
-      throw new Error(
-        'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
-      );
-
-    // Check if there's any relevant stable pool info missing
-    if (pool.tokens.some((token) => !token.decimals))
-      throw new BalancerError(BalancerErrorCode.MISSING_DECIMALS);
-    if (!pool.amp) throw new BalancerError(BalancerErrorCode.MISSING_AMP);
-
-    // Parse pool info into EVM amounts in order to match amountsIn scalling
-    const {
-      parsedTokens,
-      parsedAmp,
-      parsedTotalShares,
-      parsedSwapFee,
-      upScaledBalances,
-      scalingFactors,
-    } = parsePoolInfo(pool);
-
-    // Replace WETH address with ETH - required for exiting with ETH
-    const unwrappedTokens = parsedTokens.map((token) =>
-      token === wrappedNativeAsset ? AddressZero : token
-    );
-
-    // Sort pool info based on tokens addresses
-    const assetHelpers = new AssetHelpers(wrappedNativeAsset);
-    const [sortedTokens, sortedUpscaledBalances, sortedScalingFactors] =
-      assetHelpers.sortTokens(
-        shouldUnwrapNativeAsset ? unwrappedTokens : parsedTokens,
-        upScaledBalances,
-        scalingFactors
-      ) as [string[], string[], string[]];
-
-    let expectedAmountsOut = Array(parsedTokens.length).fill('0');
-    let minAmountsOut = Array(parsedTokens.length).fill('0');
-    let userData: string;
-
-    if (singleTokenMaxOut) {
-      // Exit pool with single token using exact bptIn
-
-      const singleTokenMaxOutIndex = parsedTokens.indexOf(singleTokenMaxOut);
-
-      // Calculate amount out given BPT in
-      const amountOut = SOR.StableMathBigInt._calcTokenOutGivenExactBptIn(
-        BigInt(parsedAmp as string),
-        sortedUpscaledBalances.map((b) => BigInt(b)),
-        singleTokenMaxOutIndex,
-        BigInt(bptIn),
-        BigInt(parsedTotalShares),
-        BigInt(parsedSwapFee)
-      ).toString();
-
-      expectedAmountsOut[singleTokenMaxOutIndex] = amountOut;
-
-      // Apply slippage tolerance
-      minAmountsOut[singleTokenMaxOutIndex] = subSlippage(
-        BigNumber.from(amountOut),
-        BigNumber.from(slippage)
-      ).toString();
-
-      userData = StablePoolEncoder.exitExactBPTInForOneTokenOut(
-        bptIn,
-        singleTokenMaxOutIndex
-      );
-    } else {
-      // Exit pool with all tokens proportinally
-
-      // Calculate amount out given BPT in
-      const amountsOut = SOR.StableMathBigInt._calcTokensOutGivenExactBptIn(
-        sortedUpscaledBalances.map((b) => BigInt(b)),
-        BigInt(bptIn),
-        BigInt(parsedTotalShares)
-      ).map((amount) => amount.toString());
-
-      // Maths return numbers scaled to 18 decimals. Must scale down to token decimals.
-      const amountsOutScaledDown = _downscaleDownArray(
-        amountsOut.map((a) => BigInt(a)),
-        sortedScalingFactors.map((a) => BigInt(a))
-      );
-
-      expectedAmountsOut = amountsOutScaledDown.map((amount) =>
-        amount.toString()
-      );
-
-      // Apply slippage tolerance
-      minAmountsOut = amountsOutScaledDown.map((amount) => {
-        const minAmount = subSlippage(
-          BigNumber.from(amount),
-          BigNumber.from(slippage)
-        );
-        return minAmount.toString();
-      });
-
-      userData = StablePoolEncoder.exitExactBPTInForTokensOut(bptIn);
-    }
-
-    const to = balancerVault;
-    const functionName = 'exitPool';
-    const attributes: ExitPool = {
+    this.checkInputsExactBPTIn({
+      bptIn,
+      singleTokenMaxOut,
+      pool,
+      shouldUnwrapNativeAsset,
+    });
+    const sortedValues = this.sortValuesExitExactBptIn({
+      pool,
+      wrappedNativeAsset,
+      shouldUnwrapNativeAsset,
+      singleTokenMaxOut,
+    });
+    const { minAmountsOut, expectedAmountsOut } =
+      sortedValues.singleTokenMaxOutIndex >= 0
+        ? this.calcTokenOutGivenExactBptIn({
+            ...sortedValues,
+            bptIn,
+            slippage,
+          })
+        : this.calcTokensOutGivenExactBptIn({
+            ...sortedValues,
+            bptIn,
+            slippage,
+          });
+    const userData =
+      sortedValues.singleTokenMaxOutIndex >= 0
+        ? StablePoolEncoder.exitExactBPTInForOneTokenOut(
+            bptIn,
+            sortedValues.singleTokenMaxOutIndex
+          )
+        : StablePoolEncoder.exitExactBPTInForTokensOut(bptIn);
+    const encodedData = this.encodeExitPool({
+      poolTokens: sortedValues.parsedTokens,
       poolId: pool.id,
-      sender: exiter,
-      recipient: exiter,
-      exitPoolRequest: {
-        assets: sortedTokens,
-        minAmountsOut,
-        userData,
-        toInternalBalance: false,
-      },
-    };
-
-    // Encode transaction data into an ABI byte string which can be sent to the network to be executed
-    const vaultInterface = Vault__factory.createInterface();
-    const data = vaultInterface.encodeFunctionData(functionName, [
-      attributes.poolId,
-      attributes.sender,
-      attributes.recipient,
-      attributes.exitPoolRequest,
-    ]);
+      exiter,
+      minAmountsOut,
+      userData,
+    });
 
     return {
-      to,
-      functionName,
-      attributes,
-      data,
+      ...encodedData,
       expectedAmountsOut,
       minAmountsOut,
     };
@@ -270,5 +191,195 @@ export class StablePoolExit implements ExitConcern {
       expectedBPTIn: bptIn,
       maxBPTIn,
     };
+  };
+  checkInputsExactBPTIn = ({
+    bptIn,
+    singleTokenMaxOut,
+    pool,
+    shouldUnwrapNativeAsset,
+  }: Pick<
+    ExitExactBPTInParameters,
+    'bptIn' | 'singleTokenMaxOut' | 'pool' | 'shouldUnwrapNativeAsset'
+  >): void => {
+    if (!bptIn.length || parseFixed(bptIn, 18).isNegative()) {
+      throw new BalancerError(BalancerErrorCode.INPUT_OUT_OF_BOUNDS);
+    }
+    if (
+      singleTokenMaxOut &&
+      singleTokenMaxOut !== AddressZero &&
+      !pool.tokens
+        .map((t) => t.address)
+        .some((a) => isSameAddress(a, singleTokenMaxOut))
+    ) {
+      throw new BalancerError(BalancerErrorCode.TOKEN_MISMATCH);
+    }
+
+    if (!shouldUnwrapNativeAsset && singleTokenMaxOut === AddressZero)
+      throw new Error(
+        'shouldUnwrapNativeAsset and singleTokenMaxOut should not have conflicting values'
+      );
+
+    // Check if there's any relevant stable pool info missing
+    if (pool.tokens.some((token) => !token.decimals))
+      throw new BalancerError(BalancerErrorCode.MISSING_DECIMALS);
+    if (!pool.amp) throw new BalancerError(BalancerErrorCode.MISSING_AMP);
+  };
+
+  sortValuesExitExactBptIn = ({
+    pool,
+    wrappedNativeAsset,
+    shouldUnwrapNativeAsset,
+    singleTokenMaxOut,
+  }: Pick<
+    ExitExactBPTInParameters,
+    | 'pool'
+    | 'wrappedNativeAsset'
+    | 'shouldUnwrapNativeAsset'
+    | 'singleTokenMaxOut'
+  >): ExactBPTInSortedValues => {
+    // Parse pool info into EVM amounts in order to match amountsIn scalling
+    const {
+      parsedTokens,
+      parsedAmp,
+      parsedTotalShares,
+      parsedSwapFee,
+      upScaledBalances,
+      scalingFactors,
+    } = parsePoolInfo(pool, wrappedNativeAsset, shouldUnwrapNativeAsset);
+    let singleTokenMaxOutIndex = -1;
+    if (singleTokenMaxOut) {
+      singleTokenMaxOutIndex = parsedTokens.indexOf(singleTokenMaxOut);
+    }
+    return {
+      parsedTokens,
+      parsedAmp,
+      parsedTotalShares,
+      parsedSwapFee,
+      upScaledBalances,
+      scalingFactors,
+      singleTokenMaxOutIndex,
+    };
+  };
+
+  calcTokenOutGivenExactBptIn = ({
+    parsedTokens,
+    parsedAmp,
+    upScaledBalances,
+    parsedTotalShares,
+    parsedSwapFee,
+    singleTokenMaxOutIndex,
+    bptIn,
+    slippage,
+  }: Pick<
+    ExactBPTInSortedValues,
+    | 'parsedTokens'
+    | 'parsedAmp'
+    | 'upScaledBalances'
+    | 'parsedTotalShares'
+    | 'parsedSwapFee'
+    | 'singleTokenMaxOutIndex'
+  > &
+    Pick<ExitExactBPTInParameters, 'bptIn' | 'slippage'>): {
+    minAmountsOut: string[];
+    expectedAmountsOut: string[];
+  } => {
+    const expectedAmountsOut = Array(parsedTokens.length).fill('0');
+    const minAmountsOut = Array(parsedTokens.length).fill('0');
+    // Calculate amount out given BPT in
+    const amountOut = SOR.StableMathBigInt._calcTokenOutGivenExactBptIn(
+      BigInt(parsedAmp as string),
+      upScaledBalances.map((b) => BigInt(b)),
+      singleTokenMaxOutIndex,
+      BigInt(bptIn),
+      BigInt(parsedTotalShares),
+      BigInt(parsedSwapFee)
+    ).toString();
+
+    expectedAmountsOut[singleTokenMaxOutIndex] = amountOut;
+
+    // Apply slippage tolerance
+    minAmountsOut[singleTokenMaxOutIndex] = subSlippage(
+      BigNumber.from(amountOut),
+      BigNumber.from(slippage)
+    ).toString();
+    return { minAmountsOut, expectedAmountsOut };
+  };
+
+  calcTokensOutGivenExactBptIn = ({
+    parsedTokens,
+    upScaledBalances,
+    parsedTotalShares,
+    scalingFactors,
+    bptIn,
+    slippage,
+  }: Pick<
+    ExactBPTInSortedValues,
+    | 'parsedTokens'
+    | 'upScaledBalances'
+    | 'parsedTotalShares'
+    | 'scalingFactors'
+    | 'singleTokenMaxOutIndex'
+  > &
+    Pick<ExitExactBPTInParameters, 'bptIn' | 'slippage'>): {
+    minAmountsOut: string[];
+    expectedAmountsOut: string[];
+  } => {
+    const amountsOut = SOR.StableMathBigInt._calcTokensOutGivenExactBptIn(
+      upScaledBalances.map((b) => BigInt(b)),
+      BigInt(bptIn),
+      BigInt(parsedTotalShares)
+    ).map((amount) => amount.toString());
+
+    // Maths return numbers scaled to 18 decimals. Must scale down to token decimals.
+    const amountsOutScaledDown = _downscaleDownArray(
+      amountsOut.map((a) => BigInt(a)),
+      scalingFactors.map((a) => BigInt(a))
+    );
+
+    const expectedAmountsOut = amountsOutScaledDown.map((amount) =>
+      amount.toString()
+    );
+
+    // Apply slippage tolerance
+    const minAmountsOut = amountsOutScaledDown.map((amount) => {
+      const minAmount = subSlippage(
+        BigNumber.from(amount),
+        BigNumber.from(slippage)
+      );
+      return minAmount.toString();
+    });
+    return { minAmountsOut, expectedAmountsOut };
+  };
+
+  encodeExitPool = ({
+    poolId,
+    exiter,
+    poolTokens,
+    minAmountsOut,
+    userData,
+  }: EncodeExitParams): ExitPoolAttributes => {
+    const to = balancerVault;
+    const functionName = 'exitPool';
+    const attributes: ExitPool = {
+      poolId,
+      sender: exiter,
+      recipient: exiter,
+      exitPoolRequest: {
+        assets: poolTokens,
+        minAmountsOut,
+        userData,
+        toInternalBalance: false,
+      },
+    };
+
+    // Encode transaction data into an ABI byte string which can be sent to the network to be executed
+    const vaultInterface = Vault__factory.createInterface();
+    const data = vaultInterface.encodeFunctionData(functionName, [
+      attributes.poolId,
+      attributes.sender,
+      attributes.recipient,
+      attributes.exitPoolRequest,
+    ]);
+    return { data, to, functionName, attributes };
   };
 }

--- a/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/stable/exit.concern.ts
@@ -322,8 +322,6 @@ export class StablePoolExit implements ExitConcern {
     minAmountsOut: string[];
     expectedAmountsOut: string[];
   } => {
-    const expectedAmountsOut = Array(parsedTokens.length).fill('0');
-    const minAmountsOut = Array(parsedTokens.length).fill('0');
     // Calculate amount out given BPT in
     const amountOut = SOR.StableMathBigInt._calcTokenOutGivenExactBptIn(
       BigInt(parsedAmp as string),
@@ -338,6 +336,9 @@ export class StablePoolExit implements ExitConcern {
       BigInt(amountOut) - BigInt(1), // The -1 is to solve rounding errors, sometimes the amount comes 1 point lower than expected
       scalingFactors[singleTokenMaxOutIndex]
     ).toString();
+
+    const expectedAmountsOut = Array(parsedTokens.length).fill('0');
+    const minAmountsOut = Array(parsedTokens.length).fill('0');
 
     expectedAmountsOut[singleTokenMaxOutIndex] = downscaledAmountOut;
     // Apply slippage tolerance
@@ -374,7 +375,7 @@ export class StablePoolExit implements ExitConcern {
     // Maths return numbers scaled to 18 decimals. Must scale down to token decimals.
     const amountsOutScaledDown = _downscaleDownArray(
       amountsOut.map((a) => BigInt(a)),
-      scalingFactors.map((a) => BigInt(a))
+      scalingFactors
     );
 
     const expectedAmountsOut = amountsOutScaledDown.map((amount) =>


### PR DESCRIPTION
Stable Exit Refactored with comments;
- Refactoring exit functions with exactBPTIn and exactTokensOut;
- Refactoring integration and unit tests, using TestPoolHelper instead of pools JSON, using old block number to avoid fee discount from amounts;
- Fixing amounts downscaling problems;