### PR TITLE
Fix bug when API Pools Data Repository reaches end of pools

### DIFF
--- a/balancer-js/src/modules/data/pool/balancer-api.ts
+++ b/balancer-js/src/modules/data/pool/balancer-api.ts
@@ -28,7 +28,7 @@ export class PoolsBalancerAPIRepository
   private client: BalancerAPIClient;
   public pools: Pool[] = [];
   public skip = 0; // Keep track of how many pools to skip on next fetch, so this functions similar to subgraph repository.
-  public nextToken: string | undefined; // A token to pass to the next query to retrieve the next page of results.
+  public nextToken: string | undefined | null; // A token to pass to the next query to retrieve the next page of results. Undefined initially, null when there are no more results.
   private query: GraphQLQuery;
 
   constructor(options: PoolsBalancerAPIOptions) {
@@ -62,7 +62,7 @@ export class PoolsBalancerAPIRepository
     delete this.query.args.skip;
   }
 
-  fetchFromCache(options?: PoolsRepositoryFetchOptions): Pool[] {
+  private fetchFromCache(options?: PoolsRepositoryFetchOptions): Pool[] {
     const first = options?.first || DEFAULT_FIRST;
     const skip = options?.skip || DEFAULT_SKIP;
 
@@ -73,8 +73,9 @@ export class PoolsBalancerAPIRepository
 
   async fetch(options?: PoolsRepositoryFetchOptions): Promise<Pool[]> {
     if (
+      this.nextToken === null ||
       this.pools.length >
-      (options?.first || DEFAULT_FIRST) + (options?.skip || DEFAULT_SKIP)
+        (options?.first || DEFAULT_FIRST) + (options?.skip || DEFAULT_SKIP)
     ) {
       return this.fetchFromCache(options);
     }


### PR DESCRIPTION
Bug: @Matthews3301 Discovered a bug with the API data repository when testing gnosis-chain in https://github.com/balancer-labs/frontend-v2/pull/2637. Gnosis chain only has 4 pools and when re-loading the pools the same 4 were continually duplicated so there were 8 results, then 12 etc. 

This happened because AppSync returns `nextToken` as `null` when you've returned all possible results. We weren't handling this and instead we were continually running the same query over and over and appending the returned pools to the cache. 

Fix: When nextToken is null, don't query the API any more, instead fetch pools only from the local cache. This does mean the Pools are not refreshed from the API but this happens for all pools currently anyway because of this local cache. 