### PR TITLE
Change to handle new Linear pools easily.

### DIFF
--- a/balancer-js/src/lib/utils/index.ts
+++ b/balancer-js/src/lib/utils/index.ts
@@ -1,3 +1,4 @@
+import { PoolType } from '@/types';
 import { getAddress } from '@ethersproject/address';
 
 export * from './aaveHelpers';
@@ -72,4 +73,11 @@ export function reorderArrays<T>(
     });
   });
   return othersResorted;
+}
+
+export function isLinearish(poolType: string): boolean {
+  const supportedPoolTypes: string[] = Object.values(PoolType);
+  if (poolType.includes('Linear') && supportedPoolTypes.includes(poolType))
+    return true;
+  else return false;
 }

--- a/balancer-js/src/modules/graph/graph.ts
+++ b/balancer-js/src/modules/graph/graph.ts
@@ -7,6 +7,8 @@ import { Findable } from '../data/types';
 import { PoolTypeConcerns } from '../pools/pool-type-concerns';
 
 type SpotPrices = { [tokenIn: string]: string };
+
+const supportedPoolTypes: string[] = Object.values(PoolType);
 export interface Node {
   address: string;
   id: string;
@@ -31,9 +33,10 @@ type JoinAction =
   | 'wrapAaveDynamicToken'
   | 'wrapERC4626';
 const joinActions = new Map<PoolType, JoinAction>();
-joinActions.set(PoolType.AaveLinear, 'batchSwap');
-joinActions.set(PoolType.EulerLinear, 'batchSwap');
-joinActions.set(PoolType.ERC4626Linear, 'batchSwap');
+supportedPoolTypes.forEach((type) => {
+  if (type.includes('Linear') && supportedPoolTypes.includes(type))
+    joinActions.set(type as PoolType, 'batchSwap');
+});
 joinActions.set(PoolType.Element, 'batchSwap');
 joinActions.set(PoolType.Investment, 'joinPool');
 joinActions.set(PoolType.LiquidityBootstrapping, 'joinPool');
@@ -51,9 +54,10 @@ type ExitAction =
   | 'unwrapAaveStaticToken'
   | 'unwrapERC4626';
 const exitActions = new Map<PoolType, ExitAction>();
-exitActions.set(PoolType.AaveLinear, 'batchSwap');
-joinActions.set(PoolType.EulerLinear, 'batchSwap');
-exitActions.set(PoolType.ERC4626Linear, 'batchSwap');
+supportedPoolTypes.forEach((type) => {
+  if (type.includes('Linear') && supportedPoolTypes.includes(type))
+    exitActions.set(type as PoolType, 'batchSwap');
+});
 exitActions.set(PoolType.Element, 'batchSwap');
 exitActions.set(PoolType.Investment, 'exitPool');
 exitActions.set(PoolType.LiquidityBootstrapping, 'exitPool');

--- a/balancer-js/src/modules/pools/pool-type-concerns.ts
+++ b/balancer-js/src/modules/pools/pool-type-concerns.ts
@@ -6,6 +6,7 @@ import { MetaStable } from './pool-types/metaStable.module';
 import { StablePhantom } from './pool-types/stablePhantom.module';
 import { Linear } from './pool-types/linear.module';
 import { BalancerError, BalancerErrorCode } from '@/balancerErrors';
+import { isLinearish } from '@/lib/utils';
 
 /**
  * Wrapper around pool type specific methods.
@@ -52,13 +53,11 @@ export class PoolTypeConcerns {
       case 'StablePhantom': {
         return new StablePhantom();
       }
-      case 'AaveLinear':
-      case 'EulerLinear':
-      case 'ERC4626Linear': {
-        return new Linear();
-      }
-      default:
+      default: {
+        // Handles all Linear pool types
+        if (isLinearish(poolType)) return new Linear();
         throw new BalancerError(BalancerErrorCode.UNSUPPORTED_POOL_TYPE);
+      }
     }
   }
 }

--- a/balancer-js/src/modules/pools/queries/get_encoder.ts
+++ b/balancer-js/src/modules/pools/queries/get_encoder.ts
@@ -2,6 +2,7 @@ import { WeightedPoolEncoder } from '@/pool-weighted/encoder';
 import { StablePoolEncoder } from '@/pool-stable/encoder';
 import { ComposableStablePoolEncoder } from '@/pool-composable-stable';
 import { PoolType } from '@/types';
+import { isLinearish } from '@/lib/utils';
 
 export const getEncoder = (
   poolType: PoolType
@@ -17,9 +18,6 @@ export const getEncoder = (
     case PoolType.Stable:
     case PoolType.MetaStable:
     case PoolType.StablePhantom:
-    case PoolType.AaveLinear:
-    case PoolType.EulerLinear:
-    case PoolType.ERC4626Linear:
     case PoolType.Element:
     case PoolType.Gyro2:
     case PoolType.Gyro3:
@@ -28,7 +26,9 @@ export const getEncoder = (
     case PoolType.ComposableStable:
       return ComposableStablePoolEncoder;
 
-    default:
+    default: {
+      if (isLinearish(poolType)) return StablePoolEncoder;
       break;
+    }
   }
 };

--- a/balancer-js/src/types.ts
+++ b/balancer-js/src/types.ts
@@ -262,14 +262,15 @@ export enum PoolType {
   MetaStable = 'MetaStable',
   StablePhantom = 'StablePhantom',
   LiquidityBootstrapping = 'LiquidityBootstrapping',
-  AaveLinear = 'AaveLinear',
-  Linear = 'Linear',
-  EulerLinear = 'EulerLinear',
-  ERC4626Linear = 'ERC4626Linear',
   Element = 'Element',
   Gyro2 = 'Gyro2',
   Gyro3 = 'Gyro3',
   Managed = 'Managed',
+  // Linear Pools defined below all operate the same mathematically but have different factories and names in Subgraph
+  AaveLinear = 'AaveLinear',
+  Linear = 'Linear',
+  EulerLinear = 'EulerLinear',
+  ERC4626Linear = 'ERC4626Linear',
 }
 
 export interface Pool {


### PR DESCRIPTION
Updates to check for "Linearish" pools. When a new Linear pool type is added it only needs to be added to `PoolType`.
Also fixes exitAction which was incorrectly adding to joinAction.