### PR TITLE
Reduce Generalised Join/Exit Gas Cost (part 2) - WIP

### DIFF
--- a/balancer-js/src/modules/exits/exits.module.ts
+++ b/balancer-js/src/modules/exits/exits.module.ts
@@ -576,7 +576,7 @@ export class Exit {
     const modelRequest = VaultModel.mapSwapRequest(call); // TODO: handle swap request in vault model
 
     // If node isn't rootNode, the swap is part of a chain and shouldn't be considered for user deltas
-    const bptIn = isRootNode ? '0' : amountIn;
+    const bptIn = !isRootNode ? '0' : amountIn;
     // If child exit action is not output, the swap is part of a chain and shouldn't be considered for user deltas
     const userTokenOutAmount =
       exitChild.exitAction !== 'output'

--- a/balancer-js/src/modules/joins/joins.module.integration.spec.ts
+++ b/balancer-js/src/modules/joins/joins.module.integration.spec.ts
@@ -25,14 +25,14 @@ import { SimulationType } from '../simulation/simulation.module';
 dotenv.config();
 
 const TEST_BOOSTED = true;
-const TEST_BOOSTED_META = true;
-const TEST_BOOSTED_META_ALT = true;
-const TEST_BOOSTED_META_BIG = true;
-const TEST_BOOSTED_WEIGHTED_SIMPLE = true;
-const TEST_BOOSTED_WEIGHTED_GENERAL = true;
-const TEST_BOOSTED_WEIGHTED_META = true;
-const TEST_BOOSTED_WEIGHTED_META_ALT = true;
-const TEST_BOOSTED_WEIGHTED_META_GENERAL = true;
+const TEST_BOOSTED_META = false;
+const TEST_BOOSTED_META_ALT = false;
+const TEST_BOOSTED_META_BIG = false;
+const TEST_BOOSTED_WEIGHTED_SIMPLE = false;
+const TEST_BOOSTED_WEIGHTED_GENERAL = false;
+const TEST_BOOSTED_WEIGHTED_META = false;
+const TEST_BOOSTED_WEIGHTED_META_ALT = false;
+const TEST_BOOSTED_WEIGHTED_META_GENERAL = false;
 
 /*
  * Testing on GOERLI
@@ -155,7 +155,7 @@ const testFlow = async (
   amountsIn: string[],
   wrapMainTokens: boolean,
   authorisation: string | undefined,
-  simulationType = SimulationType.VaultModel
+  simulationType = SimulationType.Tenderly
 ) => {
   const [bptBalanceBefore, ...tokensInBalanceBefore] = await getBalances(
     [pool.address, ...tokensIn],
@@ -193,11 +193,11 @@ const testFlow = async (
     userAddress
   );
 
-  console.table({
-    minOut: query.minOut,
-    expectedOut: query.expectedOut,
-    balanceAfter: bptBalanceAfter.toString(),
-  });
+  // console.table({
+  //   minOut: query.minOut,
+  //   expectedOut: query.expectedOut,
+  //   balanceAfter: bptBalanceAfter.toString(),
+  // });
 
   expect(receipt.status).to.eql(1);
   expect(BigNumber.from(query.minOut).gte('0')).to.be.true;

--- a/balancer-js/src/modules/joins/joins.module.integration.spec.ts
+++ b/balancer-js/src/modules/joins/joins.module.integration.spec.ts
@@ -25,14 +25,14 @@ import { SimulationType } from '../simulation/simulation.module';
 dotenv.config();
 
 const TEST_BOOSTED = true;
-const TEST_BOOSTED_META = false;
-const TEST_BOOSTED_META_ALT = false;
-const TEST_BOOSTED_META_BIG = false;
-const TEST_BOOSTED_WEIGHTED_SIMPLE = false;
-const TEST_BOOSTED_WEIGHTED_GENERAL = false;
-const TEST_BOOSTED_WEIGHTED_META = false;
-const TEST_BOOSTED_WEIGHTED_META_ALT = false;
-const TEST_BOOSTED_WEIGHTED_META_GENERAL = false;
+const TEST_BOOSTED_META = true;
+const TEST_BOOSTED_META_ALT = true;
+const TEST_BOOSTED_META_BIG = true;
+const TEST_BOOSTED_WEIGHTED_SIMPLE = true;
+const TEST_BOOSTED_WEIGHTED_GENERAL = true;
+const TEST_BOOSTED_WEIGHTED_META = true;
+const TEST_BOOSTED_WEIGHTED_META_ALT = true;
+const TEST_BOOSTED_WEIGHTED_META_GENERAL = true;
 
 /*
  * Testing on GOERLI
@@ -155,7 +155,7 @@ const testFlow = async (
   amountsIn: string[],
   wrapMainTokens: boolean,
   authorisation: string | undefined,
-  simulationType = SimulationType.Tenderly
+  simulationType = SimulationType.VaultModel
 ) => {
   const [bptBalanceBefore, ...tokensInBalanceBefore] = await getBalances(
     [pool.address, ...tokensIn],
@@ -193,11 +193,11 @@ const testFlow = async (
     userAddress
   );
 
-  // console.table({
-  //   minOut: query.minOut,
-  //   expectedOut: query.expectedOut,
-  //   balanceAfter: bptBalanceAfter.toString(),
-  // });
+  console.table({
+    minOut: query.minOut,
+    expectedOut: query.expectedOut,
+    balanceAfter: bptBalanceAfter.toString(),
+  });
 
   expect(receipt.status).to.eql(1);
   expect(BigNumber.from(query.minOut).gte('0')).to.be.true;

--- a/balancer-js/src/modules/relayer/relayer.module.ts
+++ b/balancer-js/src/modules/relayer/relayer.module.ts
@@ -28,6 +28,7 @@ import {
   FundManagement,
   BatchSwapStep,
   FetchPoolsInput,
+  Swap,
 } from '../swaps/types';
 import { SubgraphPoolBase } from '@balancer-labs/sor';
 import { RelayerAuthorization } from '@/lib/utils';
@@ -96,6 +97,18 @@ export class Relayer {
       sender,
       recipient,
       amount,
+    ]);
+  }
+
+  // TODO: check if it's ok to import Swap from swaps module - alternatives: move to common module or duplicate within relayer types
+  static encodeSwap(params: Swap): string {
+    return relayerLibrary.encodeFunctionData('swap', [
+      params.request,
+      params.funds,
+      params.limit,
+      params.deadline,
+      params.value,
+      params.outputReference,
     ]);
   }
 

--- a/balancer-js/src/modules/vaultModel/poolModel/poolModel.ts
+++ b/balancer-js/src/modules/vaultModel/poolModel/poolModel.ts
@@ -2,7 +2,7 @@ import { PoolDictionary } from '../poolSource';
 import { RelayerModel } from '../relayer';
 import { JoinModel, JoinPoolRequest } from './join';
 import { ExitModel, ExitPoolRequest } from './exit';
-import { SwapModel, BatchSwapRequest } from './swap';
+import { SwapModel, BatchSwapRequest, SwapRequest } from './swap';
 
 export class PoolModel {
   joinModel: JoinModel;
@@ -34,5 +34,12 @@ export class PoolModel {
     pools: PoolDictionary
   ): Promise<string[]> {
     return this.swapModel.doBatchSwap(batchSwapRequest, pools);
+  }
+
+  async doSingleSwap(
+    swapRequest: SwapRequest,
+    pools: PoolDictionary
+  ): Promise<string[]> {
+    return this.swapModel.doSingleSwap(swapRequest, pools);
   }
 }

--- a/balancer-js/src/modules/vaultModel/poolModel/swap.ts
+++ b/balancer-js/src/modules/vaultModel/poolModel/swap.ts
@@ -48,12 +48,14 @@ export class SwapModel {
     );
 
     const delta = Zero.sub(amountOutEvm);
+    if (!swapRequest.outputReference)
+      throw new Error('Missing outputReference');
 
     // Swap return values are signed, as they are Vault deltas (positive values correspond to assets sent
     // to the Vault, and negative values are assets received from the Vault). To simplify the chained reference
     // value model, we simply store the absolute value.
     this.relayerModel.setChainedReferenceValue(
-      Zero.toString(), // TODO: check if we have to handle this key differently
+      swapRequest.outputReference.toString(),
       delta.abs().toString()
     );
     return [delta.toString(), amountIn];

--- a/balancer-js/src/modules/vaultModel/vaultModel.module.ts
+++ b/balancer-js/src/modules/vaultModel/vaultModel.module.ts
@@ -5,7 +5,7 @@ import { PoolDataService } from '@balancer-labs/sor';
 import { PoolModel } from './poolModel/poolModel';
 import { JoinPoolRequest } from './poolModel/join';
 import { ExitPoolRequest } from './poolModel/exit';
-import { BatchSwapRequest } from './poolModel/swap';
+import { BatchSwapRequest, SwapRequest } from './poolModel/swap';
 import { RelayerModel } from './relayer';
 import { PoolsSource } from './poolSource';
 import {
@@ -13,14 +13,20 @@ import {
   EncodeJoinPoolInput,
   EncodeExitPoolInput,
 } from '../relayer/types';
+import { Swap } from '../swaps/types';
 
 export enum ActionType {
   BatchSwap,
   Join,
   Exit,
+  Swap,
 }
 
-export type Requests = BatchSwapRequest | JoinPoolRequest | ExitPoolRequest;
+export type Requests =
+  | BatchSwapRequest
+  | JoinPoolRequest
+  | ExitPoolRequest
+  | SwapRequest;
 
 /**
  * Controller / use-case layer for interacting with pools data.
@@ -60,12 +66,29 @@ export class VaultModel {
       } else if (call.actionType === ActionType.Exit) {
         const [tokens, amounts] = await poolModel.doExit(call, pools);
         this.updateDeltas(deltas, tokens, amounts);
-      } else {
+      } else if (call.actionType === ActionType.BatchSwap) {
         const swapDeltas = await poolModel.doBatchSwap(call, pools);
         this.updateDeltas(deltas, call.assets, swapDeltas);
+      } else {
+        const swapDeltas = await poolModel.doSingleSwap(call, pools);
+        this.updateDeltas(
+          deltas,
+          [call.request.assetOut, call.request.assetIn],
+          swapDeltas
+        );
       }
     }
     return deltas;
+  }
+
+  static mapSwapRequest(call: Swap): SwapRequest {
+    const swapRequest: SwapRequest = {
+      actionType: ActionType.Swap,
+      request: call.request,
+      funds: call.funds,
+      outputReference: call.outputReference,
+    };
+    return swapRequest;
   }
 
   static mapBatchSwapRequest(call: EncodeBatchSwapInput): BatchSwapRequest {


### PR DESCRIPTION
See #322 for context.

Next step taken to reduce gas cost:
- swap/batchSwap → use swap rather than batchSwap whenever performing a batchSwap with a single hop