### PR TITLE
fix: handle coingecko request errors

### DIFF
--- a/balancer-js/src/modules/data/token-prices/coingecko-historical.ts
+++ b/balancer-js/src/modules/data/token-prices/coingecko-historical.ts
@@ -37,6 +37,19 @@ export class CoingeckoHistoricalPriceRepository implements Findable<Price> {
       .then(({ data }) => {
         return data;
       })
+      .catch((error) => {
+        const message = [
+          'Error fetching historical token prices from coingecko',
+        ];
+        if (error.isAxiosError) {
+          if (error.response?.status) {
+            message.push(`with status ${error.response.status}`);
+          }
+        } else {
+          message.push(error);
+        }
+        return Promise.reject(message.join(' '));
+      })
       .finally(() => {
         console.timeEnd(`fetching coingecko historical for ${address}`);
       });

--- a/balancer-js/src/modules/data/token-prices/coingecko.spec.ts
+++ b/balancer-js/src/modules/data/token-prices/coingecko.spec.ts
@@ -56,4 +56,18 @@ describe('coingecko repository', () => {
     expect(price5?.usd).to.be.undefined;
     expect(price6?.usd).to.be.undefined;
   });
+
+  context('when the response is rate limited', () => {
+    const repository = new CoingeckoPriceRepository(addresses, 1);
+
+    it('throws error with status code', async () => {
+      const status = 429;
+      mock.onGet(new RegExp('https://api.coingecko.com/*')).reply(status);
+      try {
+        await repository.find(addresses[0]);
+      } catch (error) {
+        expect(error).to.match(new RegExp(`${status}`));
+      }
+    });
+  });
 });

--- a/balancer-js/src/modules/data/token-prices/coingecko.ts
+++ b/balancer-js/src/modules/data/token-prices/coingecko.ts
@@ -35,6 +35,17 @@ export class CoingeckoPriceRepository implements Findable<Price> {
       .then(({ data }) => {
         return data;
       })
+      .catch((error) => {
+        const message = ['Error fetching token prices from coingecko'];
+        if (error.isAxiosError) {
+          if (error.response?.status) {
+            message.push(`with status ${error.response.status}`);
+          }
+        } else {
+          message.push(error);
+        }
+        return Promise.reject(message.join(' '));
+      })
       .finally(() => {
         console.timeEnd(`fetching coingecko for ${addresses.length} tokens`);
       });
@@ -59,6 +70,17 @@ export class CoingeckoPriceRepository implements Findable<Price> {
       )
       .then(({ data }) => {
         return data[assetId];
+      })
+      .catch((error) => {
+        const message = ['Error fetching native token from coingecko'];
+        if (error.isAxiosError) {
+          if (error.response?.status) {
+            message.push(`with status ${error.response.status}`);
+          }
+        } else {
+          message.push(error);
+        }
+        return Promise.reject(message.join(' '));
       })
       .finally(() => {
         console.timeEnd(`fetching coingecko for native token`);


### PR DESCRIPTION
We are getting a lot of Coingecko network errors in Sentry. Probably due to uncaught axios errors. This is an attempt to fix this.