### PR TITLE
Fix token sorting error

### DIFF
--- a/balancer-js/src/lib/utils/index.ts
+++ b/balancer-js/src/lib/utils/index.ts
@@ -98,3 +98,7 @@ export function isLinearish(poolType: string): boolean {
     return true;
   else return false;
 }
+
+export function truncateAddresses(addresses: string[]): string[] {
+  return addresses.map((t) => `${t.slice(0, 6)}...${t.slice(38, 42)}`);
+}

--- a/balancer-js/src/modules/exits/exits.module.integration-mainnet.spec.ts
+++ b/balancer-js/src/modules/exits/exits.module.integration-mainnet.spec.ts
@@ -1,0 +1,255 @@
+// yarn test:only ./src/modules/exits/exits.module.integration-mainnet.spec.ts
+import dotenv from 'dotenv';
+import { expect } from 'chai';
+
+import { BalancerSDK, GraphQLQuery, GraphQLArgs, Network } from '@/.';
+import { BigNumber, parseFixed } from '@ethersproject/bignumber';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { Contracts } from '@/modules/contracts/contracts.module';
+import { accuracy, forkSetup, getBalances } from '@/test/lib/utils';
+import { ADDRESSES } from '@/test/lib/constants';
+import { Relayer } from '@/modules/relayer/relayer.module';
+import { JsonRpcSigner } from '@ethersproject/providers';
+import { SimulationType } from '../simulation/simulation.module';
+
+/**
+ * -- Integration tests for generalisedExit --
+ *
+ * It compares results from local fork transactions with simulated results from
+ * the Simulation module, which can be of 3 different types:
+ * 1. Tenderly: uses Tenderly Simulation API (third party service)
+ * 2. VaultModel: uses TS math, which may be less accurate (min. 99% accuracy)
+ * 3. Static: uses staticCall, which is 100% accurate but requires vault approval
+ */
+
+dotenv.config();
+
+const TEST_BBEUSD = true;
+
+/*
+ * Testing on MAINNET
+ * - Run node on terminal: yarn run node
+ * - Uncomment section below:
+ */
+const network = Network.MAINNET;
+const blockNumber = 16685902;
+const customSubgraphUrl =
+  'https://api.thegraph.com/subgraphs/name/balancer-labs/balancer-v2';
+const { ALCHEMY_URL: jsonRpcUrl } = process.env;
+const rpcUrl = 'http://127.0.0.1:8545';
+
+const addresses = ADDRESSES[network];
+
+// Set tenderly config blockNumber and use default values for other parameters
+const tenderlyConfig = {
+  blockNumber,
+};
+
+/**
+ * Example of subgraph query that allows filtering pools.
+ * Might be useful to reduce the response time by limiting the amount of pool
+ * data that will be queried by the SDK. Specially when on chain data is being
+ * fetched as well.
+ */
+const poolAddresses = Object.values(addresses).map(
+  (address) => address.address
+);
+const subgraphArgs: GraphQLArgs = {
+  where: {
+    swapEnabled: {
+      eq: true,
+    },
+    totalShares: {
+      gt: 0.000000000001,
+    },
+    address: {
+      in: poolAddresses,
+    },
+  },
+  orderBy: 'totalLiquidity',
+  orderDirection: 'desc',
+  block: { number: blockNumber },
+};
+const subgraphQuery: GraphQLQuery = { args: subgraphArgs, attrs: {} };
+
+const sdk = new BalancerSDK({
+  network,
+  rpcUrl,
+  customSubgraphUrl,
+  tenderly: tenderlyConfig,
+  subgraphQuery,
+});
+const { pools } = sdk;
+const provider = new JsonRpcProvider(rpcUrl, network);
+const signer = provider.getSigner(1); // signer 0 at this blockNumber has DAI balance and tests were failling
+const { contracts, contractAddresses } = new Contracts(
+  network as number,
+  provider
+);
+const relayer = contractAddresses.relayerV4 as string;
+
+interface Test {
+  signer: JsonRpcSigner;
+  description: string;
+  pool: {
+    id: string;
+    address: string;
+  };
+  amount: string;
+  authorisation: string | undefined;
+  simulationType?: SimulationType;
+}
+
+const runTests = async (tests: Test[]) => {
+  for (let i = 0; i < tests.length; i++) {
+    const test = tests[i];
+    it(test.description, async () => {
+      const signerAddress = await test.signer.getAddress();
+      const authorisation = await Relayer.signRelayerApproval(
+        relayer,
+        signerAddress,
+        test.signer,
+        contracts.vault
+      );
+      await testFlow(
+        test.signer,
+        signerAddress,
+        test.pool,
+        test.amount,
+        authorisation,
+        test.simulationType
+      );
+    }).timeout(120000);
+  }
+};
+
+const testFlow = async (
+  signer: JsonRpcSigner,
+  signerAddress: string,
+  pool: { id: string; address: string },
+  amount: string,
+  authorisation: string | undefined,
+  simulationType = SimulationType.VaultModel
+) => {
+  const gasLimit = 8e6;
+  const slippage = '10'; // 10 bps = 0.1%
+
+  const { to, encodedCall, tokensOut, expectedAmountsOut, minAmountsOut } =
+    await pools.generalisedExit(
+      pool.id,
+      amount,
+      signerAddress,
+      slippage,
+      signer,
+      simulationType,
+      authorisation
+    );
+
+  const [bptBalanceBefore, ...tokensOutBalanceBefore] = await getBalances(
+    [pool.address, ...tokensOut],
+    signer,
+    signerAddress
+  );
+
+  const response = await signer.sendTransaction({
+    to,
+    data: encodedCall,
+    gasLimit,
+  });
+
+  const receipt = await response.wait();
+  console.log('Gas used', receipt.gasUsed.toString());
+
+  const [bptBalanceAfter, ...tokensOutBalanceAfter] = await getBalances(
+    [pool.address, ...tokensOut],
+    signer,
+    signerAddress
+  );
+
+  console.table({
+    tokensOut: tokensOut.map((t) => `${t.slice(0, 6)}...${t.slice(38, 42)}`),
+    minOut: minAmountsOut,
+    expectedOut: expectedAmountsOut,
+    balanceAfter: tokensOutBalanceAfter.map((b) => b.toString()),
+    balanceBefore: tokensOutBalanceBefore.map((b) => b.toString()),
+  });
+
+  expect(receipt.status).to.eql(1);
+  minAmountsOut.forEach((minAmountOut) => {
+    expect(BigNumber.from(minAmountOut).gte('0')).to.be.true;
+  });
+  expectedAmountsOut.forEach((expectedAmountOut, i) => {
+    expect(
+      BigNumber.from(expectedAmountOut).gte(BigNumber.from(minAmountsOut[i]))
+    ).to.be.true;
+  });
+  expect(bptBalanceAfter.eq(bptBalanceBefore.sub(amount))).to.be.true;
+  tokensOutBalanceBefore.forEach((b) => expect(b.eq(0)).to.be.true);
+  tokensOutBalanceAfter.forEach((balanceAfter, i) => {
+    const minOut = BigNumber.from(minAmountsOut[i]);
+    expect(balanceAfter.gte(minOut)).to.be.true;
+    const expectedOut = BigNumber.from(expectedAmountsOut[i]);
+    expect(accuracy(balanceAfter, expectedOut)).to.be.closeTo(1, 1e-2); // inaccuracy should not be over to 1%
+  });
+};
+
+describe('generalised exit execution', async () => {
+  /*
+  bbeusd: ComposableStable, bbeusdt/bbeusdc/bbedai
+  bbeusdt: Linear, eUsdt/usdt
+  bbeusdc: Linear, eUsdc/usdc
+  bbedai: Linear, eDai/dai
+  */
+  context('bbeusd', async () => {
+    if (!TEST_BBEUSD) return true;
+    let authorisation: string | undefined;
+    beforeEach(async () => {
+      const tokens = [addresses.bbeusd.address];
+      const slots = [addresses.bbeusd.slot];
+      const balances = [parseFixed('2', addresses.bbeusd.decimals).toString()];
+      await forkSetup(
+        signer,
+        tokens,
+        slots,
+        balances,
+        jsonRpcUrl as string,
+        blockNumber
+      );
+    });
+
+    await runTests([
+      {
+        signer,
+        description: 'exit pool',
+        pool: {
+          id: addresses.bbeusd.id,
+          address: addresses.bbeusd.address,
+        },
+        amount: parseFixed('2', addresses.bbeusd.decimals).toString(),
+        authorisation: authorisation,
+        simulationType: SimulationType.Tenderly,
+      },
+      {
+        signer,
+        description: 'exit pool',
+        pool: {
+          id: addresses.bbeusd.id,
+          address: addresses.bbeusd.address,
+        },
+        amount: parseFixed('2', addresses.bbeusd.decimals).toString(),
+        authorisation: authorisation,
+        simulationType: SimulationType.Static,
+      },
+      {
+        signer,
+        description: 'exit pool',
+        pool: {
+          id: addresses.bbeusd.id,
+          address: addresses.bbeusd.address,
+        },
+        amount: parseFixed('2', addresses.bbeusd.decimals).toString(),
+        authorisation: authorisation,
+      },
+    ]);
+  });
+});

--- a/balancer-js/src/modules/exits/exits.module.integration.spec.ts
+++ b/balancer-js/src/modules/exits/exits.module.integration.spec.ts
@@ -2,7 +2,13 @@
 import dotenv from 'dotenv';
 import { expect } from 'chai';
 
-import { BalancerSDK, GraphQLQuery, GraphQLArgs, Network } from '@/.';
+import {
+  BalancerSDK,
+  GraphQLQuery,
+  GraphQLArgs,
+  Network,
+  truncateAddresses,
+} from '@/.';
 import { BigNumber, parseFixed } from '@ethersproject/bignumber';
 import { JsonRpcProvider } from '@ethersproject/providers';
 import { Contracts } from '@/modules/contracts/contracts.module';
@@ -189,7 +195,7 @@ const testFlow = async (
   );
 
   console.table({
-    tokensOut: tokensOut.map((t) => `${t.slice(0, 6)}...${t.slice(38, 42)}`),
+    tokensOut: truncateAddresses(tokensOut),
     minOut: minAmountsOut,
     expectedOut: expectedAmountsOut,
     balanceAfter: tokensOutBalanceAfter.map((b) => b.toString()),

--- a/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV2.concern.integration.spec.ts
+++ b/balancer-js/src/modules/pools/pool-types/concerns/composableStable/exitV2.concern.integration.spec.ts
@@ -18,13 +18,18 @@ const { ALCHEMY_URL_POLYGON: jsonRpcUrl } = process.env;
 const rpcUrl = 'http://127.0.0.1:8137';
 const provider = new ethers.providers.JsonRpcProvider(rpcUrl, network);
 const signer = provider.getSigner();
-const blockNumber = 39033320;
 const testPoolId =
   '0x373b347bc87998b151a5e9b6bb6ca692b766648a000000000000000000000923';
 let signerAddress: string;
 let pool: PoolWithMethods;
+let blockNumber: number;
 
 describe('ComposableStableV2 Exits', () => {
+  // Get most recent block number and reuse on all tests to benefit from caching
+  before(async () => {
+    blockNumber = await provider.getBlockNumber();
+  });
+
   // We have to rest the fork between each test as pool value changes after tx is submitted
   beforeEach(async () => {
     signerAddress = await signer.getAddress();
@@ -46,7 +51,7 @@ describe('ComposableStableV2 Exits', () => {
       Array(pool.tokensList.length).fill(0),
       Array(pool.tokensList.length).fill(parseFixed('100000', 18).toString()),
       jsonRpcUrl as string,
-      blockNumber // holds the same state as the static repository
+      blockNumber
     );
 
     // Updatate pool info with onchain state from fork block no

--- a/balancer-js/src/modules/vaultModel/poolModel/exit.ts
+++ b/balancer-js/src/modules/vaultModel/poolModel/exit.ts
@@ -218,10 +218,7 @@ export class ExitModel {
       );
     } else {
       // Exiting a pool is equivalent to removing from totalSupply (totalShares) so must sub here
-      pool.updateTokenBalanceForPool(
-        pool.address,
-        BigNumber.from(poolBalances[0]).sub(bptIn)
-      );
+      pool.updateTokenBalanceForPool(pool.address, pool.totalShares.sub(bptIn));
     }
 
     const tokensWithoutBpt = pool.tokensList.filter(

--- a/balancer-js/src/modules/vaultModel/poolSource.ts
+++ b/balancer-js/src/modules/vaultModel/poolSource.ts
@@ -11,8 +11,6 @@ import {
   ComposableStablePool,
 } from '@balancer-labs/sor';
 
-import { AssetHelpers } from '@/lib/utils';
-
 export interface PoolDictionary {
   [poolId: string]: Pool;
 }
@@ -41,16 +39,7 @@ export class PoolsSource {
   async all(refresh = false): Promise<SubgraphPoolBase[]> {
     if (refresh || this.poolsArray.length === 0) {
       const list = cloneDeep(await this.dataSource().getPools());
-      const assetHelpers = new AssetHelpers(this.wrappedNativeAsset);
       for (const pool of list) {
-        // Sort tokens here
-        // tokens must have same order as pool getTokens
-        const [sortedTokensList, sortedTokens] = assetHelpers.sortTokens(
-          pool.tokensList,
-          pool.tokens
-        );
-        pool.tokensList = sortedTokensList;
-        pool.tokens = sortedTokens as SubgraphToken[];
         // For non pre-minted BPT pools we add the BPT to the token list. This makes the SOR functions work for joins/exits
         if (
           [

--- a/balancer-js/src/test/lib/constants.ts
+++ b/balancer-js/src/test/lib/constants.ts
@@ -158,6 +158,41 @@ export const ADDRESSES = {
       symbol: 'wstETH_bbaUSD',
       slot: 0,
     },
+    temple_bbeusd: {
+      id: '0xa718042e5622099e5f0ace4e7122058ab39e1bbe000200000000000000000475',
+      address: '0xa718042e5622099e5f0ace4e7122058ab39e1bbe',
+      decimals: 18,
+      symbol: 'temple_bbeusd',
+      slot: 0,
+    },
+    bbeusd: {
+      id: '0x50cf90b954958480b8df7958a9e965752f62712400000000000000000000046f',
+      address: '0x50cf90b954958480b8df7958a9e965752f627124',
+      decimals: 18,
+      symbol: 'bbeusd',
+      slot: 0,
+    },
+    bbeusdt: {
+      id: '0x3c640f0d3036ad85afa2d5a9e32be651657b874f00000000000000000000046b',
+      address: '0x3c640f0d3036ad85afa2d5a9e32be651657b874f',
+      decimals: 18,
+      symbol: 'bbeusdt',
+      slot: 0,
+    },
+    bbeusdc: {
+      id: '0xd4e7c1f3da1144c9e2cfd1b015eda7652b4a439900000000000000000000046a',
+      address: '0xd4e7c1f3da1144c9e2cfd1b015eda7652b4a4399',
+      decimals: 18,
+      symbol: 'bbeusdc',
+      slot: 0,
+    },
+    bbedai: {
+      id: '0xeb486af868aeb3b6e53066abc9623b1041b42bc000000000000000000000046c',
+      address: '0xeb486af868aeb3b6e53066abc9623b1041b42bc0',
+      decimals: 18,
+      symbol: 'bbedai',
+      slot: 0,
+    },
   },
   [Network.KOVAN]: {
     // Visit https://balancer-faucet.on.fleek.co/#/faucet for test tokens


### PR DESCRIPTION
- Fix token sorting error within vault model
  - I believe this was caused by the recent changes to token order on the subgraph and SDK
  - Tests are passing, but I'm not confident that removing the token sorting present on the vault model won't cause any knock-on effects. @johngrantuk let me know what you think.
- Fix vault model incorrectly updating pool state during exits
  - Pool state being wrong don't currently cause any issues because exits don't perform consecutive operations on the same pool. It's nice to have this fixed anyway. It should follow a [fix on the SOR ](https://github.com/balancer-labs/balancer-sor/pull/368/files)
- Refactor exitGeneralised to run test on mainnet and use updated helpers
- Fix test failing due to blockNumber being too old