### PR TITLE
skipping APR integration tests

### DIFF
--- a/balancer-js/src/modules/pools/apr/apr.integration.spec.ts
+++ b/balancer-js/src/modules/pools/apr/apr.integration.spec.ts
@@ -36,7 +36,7 @@ const getMondayOfWeek = (today = new Date()) => {
   return new Date(today.setUTCDate(first));
 };
 
-describe('happy case', () => {
+describe.skip('happy case', () => {
   // Time when veBal used to receive procotol revenues
   const now = getMondayOfWeek().getTime();
 


### PR DESCRIPTION
When external data token yield sources are down tests are failing. We might be better off with unit tests only.