### PR TITLE
Fix resetting skip variable when loading pools from Balancer API

### DIFF
--- a/balancer-js/src/modules/data/pool/balancer-api.ts
+++ b/balancer-js/src/modules/data/pool/balancer-api.ts
@@ -67,7 +67,6 @@ export class PoolsBalancerAPIRepository
     const skip = options?.skip || DEFAULT_SKIP;
 
     const pools = this.pools.slice(skip, first + skip);
-    this.skip = skip + first;
     return pools;
   }
 
@@ -77,7 +76,10 @@ export class PoolsBalancerAPIRepository
       this.pools.length >
         (options?.first || DEFAULT_FIRST) + (options?.skip || DEFAULT_SKIP)
     ) {
-      return this.fetchFromCache(options);
+      const cachedPools = this.fetchFromCache(options);
+      this.skip =
+        (options?.first || DEFAULT_FIRST) + (options?.skip || DEFAULT_SKIP);
+      return cachedPools;
     }
 
     if (this.nextToken) {


### PR DESCRIPTION
The skip value is used in two ways: To keep track of where in the cache the frontend has loaded up to when repeatedly loading from the cache, or to track where in the API it's up to if loading from the API.

There was a bug where when reading from the API it would call the read from cache at the end and this would reset the skip variable to the end of the cache instead of the end of the API list. This meant that when returning a filtered list of items from the API it would request say 1000 items, but only get 90 (because of the filter), then it would set set the skip for next time to 1000 (the total requested) when the skip should have actually been 90.

This fixes that bug by only resetting the skip variable to the requested skip amount when fetching from the cache. It keeps the skip set to the total retrieved from the API when results have come from the API.