### PR TITLE
fix: broken link README.md

### DIFF
--- a/balancer-js/README.md
+++ b/balancer-js/README.md
@@ -72,7 +72,7 @@ Installation instructions for:
   - Set env var: `ALCHEMY_URL_GOERLI=[ALCHEMY HTTPS ENDPOINT for GOERLI]`
   - Run: `npm run node:goerli`
 
-- [Anvil](https://github.com/foundry-rs/foundry/tree/master/anvil#installation) - use with caution, still experimental.
+- [Anvil](https://github.com/foundry-rs/foundry/tree/master/crates/anvil#installation) - use with caution, still experimental.
 
   To start a forked node:
 


### PR DESCRIPTION
## Description
This pull request addresses a broken link in the `README.md` file. The link to the `Anvil` repository has been corrected to point to the appropriate path in the Foundry repository. 